### PR TITLE
Fix bug in block commit

### DIFF
--- a/Thundermint/Blockchain/App.hs
+++ b/Thundermint/Blockchain/App.hs
@@ -109,10 +109,7 @@ decideNewBlock appSt@AppState{..} appCh@AppChans{..} lastCommt = do
       Just Tranquility    -> loop tm
       Just Misdeed        -> loop tm
       Just (DoCommit cmt) -> do
-        blocks <- retrievePropBlocks appPropStorage $ currentH hParam
-        b <- case commitBlockID cmt `Map.lookup` blocks of
-               Just x  -> return x
-               Nothing -> error $ "Cannot commit: " ++ show cmt
+        b <- waitForBlockID appPropStorage $ commitBlockID cmt
         storeCommit appStorage appValidatorsSet cmt b
         advanceToHeight appPropStorage . next =<< blockchainHeight appStorage
         return cmt

--- a/Thundermint/Store.hs
+++ b/Thundermint/Store.hs
@@ -152,6 +152,9 @@ data ProposalStorage rw m alg a = ProposalStorage
     --   all stored data is discarded
   , retrievePropBlocks  :: Height -> m (Map (BlockID alg a) (Block alg a))
     -- ^ Retrieve blocks
+  , waitForBlockID      :: BlockID alg a -> m (Block alg a)
+    -- ^ Wait for block with given block ID. Call will block until
+    --   block appears in storage.
   , storePropBlock      :: Writable rw (Block alg a -> m ())
     -- ^ Store block proposed at given height. If height is different
     --   from height we are at block is ignored.
@@ -178,6 +181,7 @@ hoistPropStorageRW fun ProposalStorage{..} =
   ProposalStorage { currentHeight      = fun currentHeight
                   , advanceToHeight    = fun . advanceToHeight
                   , retrievePropBlocks = fun . retrievePropBlocks
+                  , waitForBlockID     = fun . waitForBlockID
                   , storePropBlock     = fun . storePropBlock
                   , allowBlockID       = \r bid -> fun (allowBlockID r bid)
                   , blockAtRound       = \h r   -> fun (blockAtRound h r)
@@ -191,6 +195,7 @@ hoistPropStorageRO fun ProposalStorage{..} =
   ProposalStorage { currentHeight      = fun currentHeight
                   , advanceToHeight    = ()
                   , retrievePropBlocks = fun . retrievePropBlocks
+                  , waitForBlockID     = fun . waitForBlockID
                   , storePropBlock     = ()
                   , allowBlockID       = ()
                   , blockAtRound       = \h r   -> fun (blockAtRound h r)

--- a/Thundermint/Store/STM.hs
+++ b/Thundermint/Store/STM.hs
@@ -93,6 +93,12 @@ newSTMPropStorage = do
         if h == height then readTVar varPBlk
                        else return Map.empty
     --
+    , waitForBlockID = \bid -> atomically $ do
+        bmap <- readTVar varPBlk
+        case bid `Map.lookup` bmap of
+          Nothing -> retry
+          Just b  -> return b
+    --
     , storePropBlock = \blk -> atomically $ do
         h <- readTVar varH
         when (headerHeight (blockHeader blk) == h) $ do


### PR DESCRIPTION
Before commit code assumed that block will be present in the
proposal storage at the moment of commit. That's not correct.
If we're catching up node will receive precommits for commit
and then will start accepting block so it's likely that it won't
have block when we get to commit phase