### PR TITLE
Add support for non-validating nodes

### DIFF
--- a/Thundermint/Blockchain/Types.hs
+++ b/Thundermint/Blockchain/Types.hs
@@ -44,8 +44,8 @@ data AppState m alg a = AppState
   , appBlockGenerator :: m a
     -- ^ Generate fresh block for proposal. It's called each time we
     --   need to create new block for proposal
-  , appValidator      :: PrivValidator alg
-    -- ^ Private validator for node
+  , appValidator      :: Maybe (PrivValidator alg)
+    -- ^ Private validator for node. It's @Nothing@ if node is not a validator
   , appValidationFun  :: a -> m Bool
     -- ^ Function for validation of proposed block data.
   , appValidatorsSet  :: ValidatorSet alg

--- a/exe/key-val-sql.hs
+++ b/exe/key-val-sql.hs
@@ -91,7 +91,7 @@ main = do
                                                ["K_" ++ show (n :: Int) | n <- [1 ..]] 
                                   return [(k,i)]
                     --
-                    , appValidator     = val
+                    , appValidator     = Just val
                     , appValidatorsSet = validatorSet
                     , appMaxHeight     = Just (Height 9)
                     }

--- a/exe/network.hs
+++ b/exe/network.hs
@@ -86,7 +86,7 @@ main = do
                     , appBlockGenerator = do
                         Height h <- blockchainHeight storage
                         return $ h * 100
-                    , appValidator     = val
+                    , appValidator     = Just val
                     , appValidatorsSet = validatorSet
                     , appMaxHeight     = Just (Height 3)
                     }

--- a/exe/node.hs
+++ b/exe/node.hs
@@ -145,7 +145,7 @@ main = do
              , appBlockGenerator = do
                  Height h <- blockchainHeight storage
                  return $ h * 100
-             , appValidator     = val
+             , appValidator     = Just val
              , appValidatorsSet = validatorSet
              , appMaxHeight     = Just (Height 3)
              }

--- a/exe/simple.hs
+++ b/exe/simple.hs
@@ -61,7 +61,7 @@ main = do
                     , appBlockGenerator = do
                         Height h <- blockchainHeight storage
                         return $ h * 100
-                    , appValidator     = val
+                    , appValidator     = Just val
                     , appValidatorsSet = validatorSet
                     , appMaxHeight     = Just (Height 3)
                     }


### PR DESCRIPTION
This allows to add nodes into network which do not do validation
but participate in gossip and ontain blockchain state using consensus
algorithm.

In conttext of exchange this is needed for nodes which submit bids and
monitor blockchain state but do not partaker in validation themselves