### PR TITLE
Improve performance of filtering mempool

### DIFF
--- a/Thundermint/Store.hs
+++ b/Thundermint/Store.hs
@@ -228,8 +228,7 @@ data Mempool m tx = Mempool
     --   that all transactions will be returned. This operation does
     --   not alter mempool state
   , filterMempool     :: m ()
-    -- ^ Run check on every transaction in mempool and remove ones
-    --   that do not pass it.
+    -- ^ Remove transactions that are no longer valid from mempool
   , getMempoolCursor  :: m (MempoolCursor m tx)
     -- ^ Get cursor pointing to be
   , mempoolSize       :: m Int


### PR DESCRIPTION
Old algorithm was quandratic and would start permorm very poorly
once number of transactions would hit  few thousands new transactions
would be added faster than they're removed resulting in uncontrolled
growth of mempool

It's not only possible solution for removing no longer valid transactions 
but it seems to work