### PR TITLE
Downgrade versions

### DIFF
--- a/Thundermint/Blockchain/Interpretation.hs
+++ b/Thundermint/Blockchain/Interpretation.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE DataKinds       #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RankNTypes      #-}
 -- |
 -- Encoding of application-specific logic for blockchain
 module Thundermint.Blockchain.Interpretation (
     BlockFold(..)
   , BChState(..)
   , newBChState
+  , hoistBChState
   ) where
 
 import Control.Concurrent.MVar
@@ -85,3 +87,8 @@ newBChState BlockFold{..} BlockStorage{..} = do
     { currentState = withMVarM state (return . snd)
     , stateAtH     = ensureHeight
     }
+
+hoistBChState :: (forall a . m a -> n a) -> BChState m s -> BChState n s
+hoistBChState f BChState{..} = BChState
+  { currentState = f currentState
+  , stateAtH     = f . stateAtH }

--- a/exe/node.hs
+++ b/exe/node.hs
@@ -25,7 +25,7 @@ import Network.Socket
     , getAddrInfo
     , getNameInfo
     , listen
-    , setCloseOnExecIfNeeded
+    -- , setCloseOnExecIfNeeded
     , setSocketOption
     , socket
     )
@@ -119,7 +119,9 @@ waitForAddrs = do
         -- If the prefork technique is not used,
         -- set CloseOnExec for the security reasons.
         let fd = fdSocket sock
-        setCloseOnExecIfNeeded fd
+        -- TODO: commented to use network-2.6.*
+        --       fix to provide on-close behavior
+        -- setCloseOnExecIfNeeded fd
         listen sock 10
         return sock
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -45,9 +45,9 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
     - async-2.2.1
-    - exceptions-0.8
+    - exceptions-0.8.3
     - katip-0.5.4.0
-    - network-2.6.0.0
+    - network-2.6.3.6
     - serialise-0.2.0.0
     - cborg-0.2.0.0
     - base58-bytestring-0.1.0

--- a/thundermint.cabal
+++ b/thundermint.cabal
@@ -25,7 +25,7 @@ Library
                      , directory
                      , deepseq           >=1.4
                      , filepath
-                     , exceptions        >=0.10.0
+                     , exceptions        >= 0.8.3
                      , memory            >=0.14.14
                      , random
                      , stm               >=2.4
@@ -35,7 +35,7 @@ Library
                      , transformers      >=0.5
                      , unordered-containers >=0.2.5.0
                      --
-                     , network           >=2.7.0.0
+                     , network           >=2.6.0.0
                      , katip             >=0.5.4.0
                      , cryptonite        >=0.25
                      --
@@ -99,7 +99,7 @@ Executable thundermint-simple-network
                      , bytestring >=0.10
                      , base58-bytestring >=0.1
                      , containers >=0.5.7
-                     , network    >=2.7.0.0
+                     , network    >=2.6.0.0
   hs-source-dirs:      exe
   Main-is:             network.hs
 
@@ -112,7 +112,7 @@ Executable thundermint-node
                      , bytestring >=0.10
                      , base58-bytestring >=0.1
                      , containers >=0.5.7
-                     , network    >=2.7.0.0
+                     , network    >=2.6.0.0
                      , text
   hs-source-dirs:      exe
   Main-is:             node.hs


### PR DESCRIPTION
Понижены версии пакетов exceptions и network.
Иначе не собирается с биржей. 
В бирже есть ограничение по вресии серванта и он янет за собой понижение
для этих пакетов.

Также добавлена функция `hoist` для `BChState`.