### PR TITLE
Small tweks to POL in proposals

### DIFF
--- a/Thundermint/Consensus/Types.hs
+++ b/Thundermint/Consensus/Types.hs
@@ -160,7 +160,7 @@ data Proposal alg a = Proposal
     -- ^ Propoasl round
   , propTimestamp :: Time
     -- ^ Time of proposal
-  , propPOL       :: Maybe (Round, BlockID alg a)
+  , propPOL       :: Maybe Round
     -- ^ Proof of Lock for proposal
     --
     -- FIXME: why it's needed? How should it be used?


### PR DESCRIPTION
We don't need to include BlockID into POL in proposal since valid node must propose it anyway. No point in duplication. Also check that POL round is before round of proposal. There's still need to update gossip to make use POL information for node but I don't think it's urgent