### PR TITLE
Test key val issue 105

### DIFF
--- a/Thundermint/Mock/Store.hs
+++ b/Thundermint/Mock/Store.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE FlexibleContexts #-}
+module Thundermint.Mock.Store (
+   newBlockStorage
+ ) where
+
+import Codec.Serialise  (Serialise)
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath  (splitFileName, (</>))
+
+import Thundermint.Consensus.Types
+import Thundermint.Crypto
+import Thundermint.Crypto.Containers
+import Thundermint.Store
+import Thundermint.Store.SQLite
+import Thundermint.Store.STM
+
+-- | Create block storage. It will use SQLite if path is specified or
+--   STM otherwise.
+newBlockStorage
+  :: (Crypto alg, Serialise a, Serialise (PublicKey alg))
+  => FilePath                   -- ^ Prefix
+  -> Maybe FilePath             -- ^ Path to database
+  -> Block alg a
+  -> ValidatorSet alg
+  -> IO (BlockStorage 'RW IO alg a)
+newBlockStorage prefix mpath genesis validatorSet = do
+  let makedir path = let (dir,_) = splitFileName path
+                     in createDirectoryIfMissing True dir
+  case mpath of
+      Nothing -> newSTMBlockStorage genesis validatorSet
+      Just nm -> do
+        let dbName = prefix </> nm
+        makedir dbName
+        newSQLiteBlockStorage dbName genesis validatorSet

--- a/Thundermint/Mock/Types.hs
+++ b/Thundermint/Mock/Types.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Thundermint.Mock.Types (
+  NodeSpec(..)
+, NetSpec(..)
+, Topology(..)
+, Abort(..)
+, defCfg
+  ) where
+
+import Control.Exception
+
+import GHC.Generics (Generic)
+
+import qualified Data.Aeson as JSON
+
+
+import Thundermint.Crypto.Ed25519 (Ed25519_SHA512)
+import Thundermint.Logger         (ScribeSpec)
+
+import Thundermint.Blockchain.Types
+
+
+
+defCfg :: Configuration
+defCfg = Configuration
+  { timeoutNewHeight   = (500, 500)
+  , timeoutProposal    = (500, 500)
+  , timeoutPrevote     = (500, 500)
+  , timeoutPrecommit   = (500, 500)
+  , gossipDelayVotes   = 25
+  , gossipDelayBlocks  = 25
+  , gossipDelayMempool = 25
+  }
+
+
+----------------------------------------------------------------
+-- Generating node specification
+----------------------------------------------------------------
+data Abort = Abort
+  deriving Show
+instance Exception Abort
+
+
+
+data Topology = All2All
+              | Ring
+              deriving (Generic,Show)
+instance JSON.ToJSON   Topology
+instance JSON.FromJSON Topology
+
+data NodeSpec = NodeSpec
+  { nspecPrivKey    :: Maybe (PrivValidator Ed25519_SHA512)
+  , nspecDbName     :: Maybe FilePath
+  , nspecLogFile    :: [ScribeSpec]
+  , nspecWalletKeys :: (Int,Int)
+  , nspecByzantine  :: Maybe String
+  }
+  deriving (Generic,Show)
+
+data NetSpec = NetSpec
+  { netNodeList       :: [NodeSpec]
+  , netTopology       :: Topology
+  , netInitialDeposit :: Integer
+  , netInitialKeys    :: Int
+  , netPrefix         :: Maybe String
+  }
+  deriving (Generic,Show)
+
+instance JSON.ToJSON   NodeSpec
+instance JSON.ToJSON   NetSpec
+instance JSON.FromJSON NodeSpec
+instance JSON.FromJSON NetSpec

--- a/exe/coin-node.hs
+++ b/exe/coin-node.hs
@@ -17,7 +17,6 @@ import Codec.Serialise      (serialise)
 import Control.Monad        (forever)
 import Data.ByteString.Lazy (toStrict)
 import Data.Maybe           (isJust)
-import GHC.Generics         (Generic)
 import Katip.Core           (LogEnv, showLS)
 import Network.Simple.TCP   (accept, listen, recv)
 import Network.Socket       (SockAddr(..))
@@ -31,14 +30,15 @@ import Thundermint.Consensus.Types
 import Thundermint.Control
 import Thundermint.Crypto
 import Thundermint.Crypto.Containers
-import Thundermint.Crypto.Ed25519    (Ed25519_SHA512)
+import Thundermint.Crypto.Ed25519            (Ed25519_SHA512)
 import Thundermint.Logger
 import Thundermint.Mock
 import Thundermint.Mock.Coin
 import Thundermint.Mock.KeyList
+import Thundermint.Mock.Types
 import Thundermint.P2P.Consts
 import Thundermint.P2P.Instances ()
-import Thundermint.P2P.Network       (getLocalAddress, realNetwork)
+import Thundermint.P2P.Network               (getLocalAddress, realNetwork)
 import Thundermint.Store
 import Thundermint.Store.STM
 
@@ -48,20 +48,8 @@ import qualified Data.ByteString.Char8 as BC8
 import qualified Data.Map              as Map
 
 ----------------------------------------------------------------
--- Generating node specification
+-- Cmd line specification
 ----------------------------------------------------------------
-
-data NodeSpec = NodeSpec
-  { nspecPrivKey    :: Maybe (PrivValidator Ed25519_SHA512)
-  , nspecDbName     :: Maybe FilePath
-  , nspecLogFile    :: [ScribeSpec]
-  , nspecWalletKeys :: (Int,Int)
-  }
-  deriving (Generic,Show)
-
-instance JSON.ToJSON   NodeSpec
-instance JSON.FromJSON NodeSpec
-
 data Opts = Opts
   { maxH              :: Maybe Int64
   , prefix            :: FilePath

--- a/exe/coin.hs
+++ b/exe/coin.hs
@@ -13,16 +13,16 @@ import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.IO.Class
 import Data.Foldable
-import Data.Maybe           (isJust)
 import Data.Int
+import Data.Maybe             (isJust)
 import Data.Monoid
 import Options.Applicative
 
 import Codec.Serialise      (serialise)
 import Data.ByteString.Lazy (toStrict)
-import GHC.Generics         (Generic)
-import System.FilePath      ((</>))
-import System.Random        (randomRIO)
+
+import System.FilePath ((</>))
+import System.Random   (randomRIO)
 
 
 import qualified Data.Aeson            as JSON
@@ -30,45 +30,19 @@ import qualified Data.ByteString.Char8 as BC8
 import qualified Data.Map              as Map
 
 import Thundermint.Blockchain.Interpretation
-import Thundermint.Blockchain.Types
 import Thundermint.Consensus.Types
 import Thundermint.Control
 import Thundermint.Crypto
-import Thundermint.Crypto.Ed25519            (Ed25519_SHA512)
-import Thundermint.Store.STM
 import Thundermint.Logger
 import Thundermint.Mock
 import Thundermint.Mock.Coin
 import Thundermint.Mock.KeyList
+import Thundermint.Mock.Types
 import Thundermint.P2P.Network
 import Thundermint.Store
 import Thundermint.Store.SQLite
+import Thundermint.Store.STM
 
-----------------------------------------------------------------
--- Generating node specification
-----------------------------------------------------------------
-
-data NodeSpec = NodeSpec
-  { nspecPrivKey    :: Maybe (PrivValidator Ed25519_SHA512)
-  , nspecDbName     :: Maybe FilePath
-  , nspecLogFile    :: [ScribeSpec]
-  , nspecWalletKeys :: (Int,Int)
-  }
-  deriving (Generic,Show)
-
-data NetSpec = NetSpec
-  { netNodeList       :: [NodeSpec]
-  , netTopology       :: Topology
-  , netInitialDeposit :: Integer
-  , netInitialKeys    :: Int
-  , netPrefix         :: Maybe String
-  }
-  deriving (Generic,Show)
-
-instance JSON.ToJSON   NodeSpec
-instance JSON.ToJSON   NetSpec
-instance JSON.FromJSON NodeSpec
-instance JSON.FromJSON NetSpec
 
 ----------------------------------------------------------------
 -- Generation of transactions

--- a/exe/key-val.hs
+++ b/exe/key-val.hs
@@ -1,141 +1,15 @@
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE TypeFamilies      #-}
 
 import Control.Monad
-import Control.Monad.Catch
-import Control.Monad.IO.Class
-import Data.Int
-import Data.List
+import Data.Monoid         ((<>))
 import Options.Applicative
-import System.FilePath
-
-import Data.Maybe   (isJust)
-import Data.Monoid  ((<>))
-import GHC.Generics (Generic)
 
 import qualified Data.Aeson            as JSON
 import qualified Data.ByteString.Char8 as BC8
-import qualified Data.Map              as Map
 
-import Thundermint.Blockchain.App
-import Thundermint.Blockchain.Interpretation
-import Thundermint.Blockchain.Types
-import Thundermint.Consensus.Types
-import Thundermint.Control
-import Thundermint.Crypto.Ed25519            (Ed25519_SHA512)
-import Thundermint.Logger
-import Thundermint.Mock
 import Thundermint.Mock.KeyVal
-import Thundermint.P2P
-import Thundermint.P2P.Network
 import Thundermint.Store
 
-----------------------------------------------------------------
---
-----------------------------------------------------------------
 
-data NodeSpec = NodeSpec
-  { nspecPrivKey   :: Maybe (PrivValidator Ed25519_SHA512)
-  , nspecByzantine :: Maybe String
-  , nspecDbName    :: Maybe FilePath
-  , nspecLogFile   :: [ScribeSpec]
-  }
-  deriving (Generic,Show)
-
-data NetSpec = NetSpec
-  { netNodeList :: [NodeSpec]
-  , netTopology :: Topology
-  , netPrefix   :: Maybe String
-  }
-  deriving (Generic,Show)
-
-instance JSON.ToJSON   NodeSpec
-instance JSON.ToJSON   NetSpec
-instance JSON.FromJSON NodeSpec
-instance JSON.FromJSON NetSpec
-
-
-interpretSpec
-  :: Maybe Int64                -- ^ Maximum height
-  -> FilePath
-  -> NetSpec                    --
-  -> IO [(BlockStorage 'RO IO Ed25519_SHA512 [(String,Int)], IO ())]
-interpretSpec maxH prefix NetSpec{..} = do
-  net <- newMockNet
-  forM (Map.toList netAddresses) $ \(addr, NodeSpec{..}) -> do
-    -- Prepare logging
-    let loggers = [ makeScribe s { scribe'path = fmap (prefix </>) (scribe'path s) }
-                  | s <- nspecLogFile
-                  ]
-    -- Create storage
-    storage  <- newBlockStorage prefix nspecDbName genesisBlock validatorSet
-    hChain   <- blockchainHeight storage
-    --
-    withLogEnv "TM" "DEV" loggers $ \logenv -> runLoggerT "general" logenv $ do
-      -- Blockchain state
-      bchState <- newBChState transitions
-                $ makeReadOnly (hoistBlockStorageRW liftIO storage)
-      _        <- stateAtH bchState (next hChain)
-      let appState = AppState
-            { appStorage        = hoistBlockStorageRW liftIO storage
-            --
-            , appValidationFun  = \h a -> do
-                st <- stateAtH bchState h
-                return $ isJust $ processBlock transitions h a st
-            --
-            , appBlockGenerator = \h -> case nspecByzantine of
-                Just "InvalidBlock" -> do
-                  return [("XXX", 123)]
-                _ -> do
-                  st <- stateAtH bchState h
-                  let Just k = find (`Map.notMember` st) ["K_" ++ show (n :: Int) | n <- [1 ..]]
-                  return [(k, addr)]
-            --
-            , appCommitCallback = \case
-                h | Just h' <- maxH
-                  , h > Height h'   -> throwM Abort
-                  | otherwise       -> return ()
-            , appValidator        = nspecPrivKey
-            , appNextValidatorSet = \_ _ -> return validatorSet
-            }
-      appCh <- newAppChans
-      return ( makeReadOnly storage
-             , runLoggerT "general" logenv $ runConcurrently
-                 [ setNamespace "net"
-                   $ startPeerDispatcher
-                       defCfg
-                       (createMockNode net "50000" addr)
-                       (addr,"50000")
-                       (map (,"50000") $ connections netAddresses addr)
-                       appCh
-                       (hoistBlockStorageRO liftIO $ makeReadOnly storage)
-                       nullMempool
-                 , setNamespace "consensus"
-                   $ runApplication defCfg appState appCh
-                 ]
-             )
-  where
-    netAddresses = Map.fromList $ [0::Int ..] `zip` netNodeList
-    connections  = case netTopology of
-      Ring    -> connectRing
-      All2All -> connectAll2All
-    validatorSet = makeValidatorSetFromPriv [ pk | Just pk <- nspecPrivKey <$> netNodeList ]
-
-
-executeSpec
-  :: Maybe Int64                -- ^ Maximum height
-  -> FilePath
-  -> NetSpec                    --
-  -> IO [BlockStorage 'RO IO Ed25519_SHA512 [(String,Int)]]
-executeSpec maxH prefix spec = do
-  actions <- interpretSpec maxH prefix spec
-  runConcurrently (snd <$> actions) `catch` (\Abort -> return ())
-  return $ fst <$> actions
 
 main :: IO ()
 main
@@ -153,14 +27,9 @@ main
         Right s -> return s
         Left  e -> error e
       storageList <- executeSpec maxH prefix spec
-      -- Check result
-      checks <- forM storageList $ \storage -> do
-                              bs <- checkBlocks storage
-                              cs <- checkCommits storage
-                              vs <- checkValidators storage
-                              cbs <- checkCommitsBlocks storage
-                              return $ bs <> cs <> vs <> cbs
-      unless (null (concat checks)) $ error $ "Consistency error: " ++ (show checks)
+      -- Check result against consistency invariants
+      checks <- forM storageList checkStorage
+      unless (null (concat checks)) $ error $ "Consistency problem: " ++ (show checks)
     ----------------------------------------
     parser :: Parser (IO ())
     parser
@@ -180,7 +49,3 @@ main
          (  help "Specification file"
          <> metavar "JSON"
          )
-
-allEq :: Eq a => [a] -> Bool
-allEq []     = True
-allEq (x:xs) = all (x ==) xs

--- a/exe/tls-coin-node.hs
+++ b/exe/tls-coin-node.hs
@@ -31,14 +31,16 @@ import Thundermint.Consensus.Types
 import Thundermint.Control
 import Thundermint.Crypto
 import Thundermint.Crypto.Containers
-import Thundermint.Crypto.Ed25519    (Ed25519_SHA512)
+import Thundermint.Crypto.Ed25519            (Ed25519_SHA512)
 import Thundermint.Logger
 import Thundermint.Mock
 import Thundermint.Mock.Coin
 import Thundermint.Mock.KeyList
+import Thundermint.Mock.Types
 import Thundermint.P2P.Consts
 import Thundermint.P2P.Instances ()
-import Thundermint.P2P.Network    (getCredentialFromBuffer, getLocalAddress, realNetworkTls)
+import Thundermint.P2P.Network
+    (getCredentialFromBuffer, getLocalAddress, realNetworkTls)
 import Thundermint.Store
 import Thundermint.Store.STM
 
@@ -49,19 +51,8 @@ import qualified Data.ByteString.Char8 as BC8
 import qualified Data.Map              as Map
 
 ----------------------------------------------------------------
--- Generating node specification
+-- Cmd line specification
 ----------------------------------------------------------------
-
-data NodeSpec = NodeSpec
-  { nspecPrivKey    :: Maybe (PrivValidator Ed25519_SHA512)
-  , nspecDbName     :: Maybe FilePath
-  , nspecLogFile    :: [ScribeSpec]
-  , nspecWalletKeys :: (Int,Int)
-  }
-  deriving (Generic,Show)
-
-instance JSON.ToJSON   NodeSpec
-instance JSON.FromJSON NodeSpec
 
 data Opts = Opts
   { maxH              :: Maybe Int64

--- a/spec/keyval-stm.json
+++ b/spec/keyval-stm.json
@@ -2,12 +2,13 @@
   "netNodeList" :
   [
     { "nspecPrivKey"     : "2K7bFuJXxKf5LqogvVRQjms2W26ZrjpvUjo5LdvPFa5Y",
-      "nspecLogFile"     : 
+      "nspecLogFile"     :
       [{ "type"      : "ScribeJSON",
          "path"      : "logs/node-1",
          "severity"  : "Debug",
          "verbosity" : "V2"
-      }]
+       }],
+        "nspecWalletKeys"  : [0,0]
     },
     { "nspecPrivKey"     : "4NSWtMsEPgfTK25tCPWqNzVVze1dgMwcUFwS5WkSpjJL",
       "nspecByzantine"   : "InvalidBlock",
@@ -16,7 +17,8 @@
          "path"      : "logs/node-2",
          "severity"  : "Debug",
          "verbosity" : "V2"
-      }]
+       }],
+        "nspecWalletKeys"  : [0,0]
     },
     { "nspecPrivKey"     : "3Fj8bZjKc53F2a87sQaFkrDas2d9gjzK57FmQwnNnSHS",
       "nspecLogFile"     :
@@ -24,7 +26,8 @@
          "path"      : "logs/node-3",
          "severity"  : "Debug",
          "verbosity" : "V2"
-      }]
+       }],
+        "nspecWalletKeys"  : [0,0]
     },
     { "nspecPrivKey"     : "D2fpHM1JA8trshiUW8XPvspsapUvPqVzSofaK1MGRySd",
       "nspecLogFile"     :
@@ -32,8 +35,12 @@
          "path"      : "logs/node-4",
          "severity"  : "Debug",
          "verbosity" : "V2"
-      }]
+       }],
+        "nspecWalletKeys"  : [0,0]
     }
   ],
-  "netTopology"       : "All2All"
+  "netTopology"       : "All2All",
+  "netInitialDeposit" : 1000,
+  "netInitialKeys"    : 2000
+
 }

--- a/test/TM/Store.hs
+++ b/test/TM/Store.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -fno-warn-unused-top-binds #-} {- allow useful top functions for GHCi -}
 
 module TM.Store ( tests) where
 
@@ -7,23 +8,48 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import Control.Monad    (unless, when)
+import Data.Int         (Int64)
 import Data.Monoid      ((<>))
+import Data.Traversable (forM)
 import System.Directory (doesFileExist)
+
+import qualified Data.Aeson            as JSON
+import qualified Data.ByteString.Char8 as BC8
 
 import Thundermint.Mock.Coin
 import Thundermint.Store
 import Thundermint.Store.SQLite
 
+import qualified Thundermint.Mock.KeyVal as KeyVal
+
+
+maxHeight :: Int64
+maxHeight = 10
+
 tests :: TestTree
 tests =
-    testGroup "blockchain validity test"
-                  [ testGroup "existence"
-                                  [ testCase "node-1" $ checkBlockchainInvariants "./test-data/valitidy/node-1.sqlite"
-                                  , testCase "node-2" $ checkBlockchainInvariants "./test-data/valitidy/node-2.sqlite"
-                                  , testCase "node-3" $ checkBlockchainInvariants "./test-data/valitidy/node-3.sqlite"
-                                  , testCase "node-4" $ checkBlockchainInvariants "./test-data/valitidy/node-4.sqlite"
+    testGroup "generate blockchain and check on consistency"
+                  [ testGroup "blockhains"
+                                  [ testCase "key-val db" $ runKeyVal (Just maxHeight)  "./test-data/key-val" "spec/simple.json"
+                                  -- , testCase "key-val stm" $ runKeyVal (Just maxHeight)  "./test-data/key-val" "spec/keyval-stm.json"
                                   ]
                   ]
+
+-- Run key-val blockchain mock
+runKeyVal :: Maybe Int64 -> FilePath -> FilePath -> IO ()
+runKeyVal maxH prefix file = do
+      -- read config
+      blob <- BC8.readFile file
+      spec <- case JSON.eitherDecodeStrict blob of
+        Right s -> return s
+        Left  e -> error e
+      storageList <- KeyVal.executeSpec maxH prefix spec
+      -- Check result against consistency invariants
+      checks <- forM storageList checkStorage
+      assertEqual "failed consistency check" [] (concat checks)
+
+
+
 checkBlockchainInvariants :: FilePath -> IO ()
 checkBlockchainInvariants dbName = do
   b <- doesFileExist dbName

--- a/thundermint.cabal
+++ b/thundermint.cabal
@@ -70,6 +70,8 @@ Library
                   Thundermint.Mock.Coin
                   Thundermint.Mock.KeyList
                   Thundermint.Mock.KeyVal
+                  Thundermint.Mock.Types
+                  Thundermint.Mock.Store
                   Thundermint.P2P
                   Thundermint.P2P.Consts
                   Thundermint.P2P.Instances
@@ -227,6 +229,7 @@ Test-suite thundermint-tests
                      , stm        >=2.4
                      , async      >=2.2.1
                      , directory
+                     , aeson
                      --
                      , network           >=2.7.0.0
                      , tls               >=1.4.1


### PR DESCRIPTION
use key-val blockchain generation in tests, check consistency.

move some types in common place from coin-node, tls-coin-node as well.
TODO: run by terraform for test the changes for coin-node and tls-coin-node.
