### PR TITLE
Fix deadlock of consensus (By disabling check)

### DIFF
--- a/Thundermint/Consensus/Algorithm.hs
+++ b/Thundermint/Consensus/Algorithm.hs
@@ -429,9 +429,18 @@ enterPrevote par@HeightParameters{..} r (unlockOnPrevote -> sm@TMState{..}) reas
                   , voteBlockID v == Just propBlockID -> checkPrevoteBlock propBlockID
                   | otherwise                         -> do
                       --  FIXME: Byzantine!
-                      logger WarningS "BYZANTINE proposal BID does not match votes" ()
+                      logger WarningS "BYZANTINE proposal POL BID does not match votes" ()
                       return Nothing
-                Nothing                               -> return Nothing
+                --
+                -- FIXME: Here we allow block even if we don't have
+                --        POL for the round it's locked on. We need to
+                --        do this because in order to perform that
+                --        check we need to gossip POL votes with
+                --        priority and we don't have support for that
+                --        yet
+                --
+                -- Nothing                               -> return Nothing
+                Nothing                               -> checkPrevoteBlock propBlockID
             Nothing                                   -> checkPrevoteBlock propBlockID
       -- Proposal invalid or absent. Prevote NIL
       | otherwise                          = return Nothing


### PR DESCRIPTION
Deadlock was caused by requiring POL for locked proposal. But that could happen that node don't have it and gossip does not have gossip of POL votes as special case.

As workaround this check is disabled. It looks like it's really optional and could be omitted without compromising blockchain integrity. At any rate it seems to be best course of action at the moment

(Also see #51)