### PR TITLE
Partial fix for #141

### DIFF
--- a/notebook/run-jupyter.sh
+++ b/notebook/run-jupyter.sh
@@ -2,4 +2,4 @@
 #
 # Start jupyter notebook server
 set -e
-nix-shell --command 'PYTHONPATH=$(pwd) jupyter notebook' jupyter.nix
+nix-shell --command 'PYTHONPATH=$(pwd) jupyter notebook --no-browser' jupyter.nix


### PR DESCRIPTION
This fixes some aspects of collecting straggler precommits

 1) Only precommits from commit round are accepted
 2) Duplicate commits are disarded

We however do not check whether we have diverging votes from
same validator so it's possible to create invalid commit in presence
of byzantine nodes thus #143 is not completely covered

(#142 is vaguely related)