### PR TITLE
Some reafactoring of proposal storage

### DIFF
--- a/thundermint/Thundermint/P2P.hs
+++ b/thundermint/Thundermint/P2P.hs
@@ -730,7 +730,7 @@ peerGossipBlocks peerObj PeerChans{..} gossipCh = logOnException $ do
       --
       Current p -> do
         let FullStep h r _ = peerStep p
-        mbid <- blockAtRound proposalStorage h r
+        mbid <- retrievePropByR proposalStorage h r
         case () of
            -- Peer has proposal but not block
           _| Just (b,bid) <- mbid

--- a/thundermint/Thundermint/P2P/PeerState.hs
+++ b/thundermint/Thundermint/P2P/PeerState.hs
@@ -369,7 +369,7 @@ addBlockHR (PeerStateObj _ ProposalStorage{..} var) h r =
     Current p
       | FullStep hP _ _ <- peerStep p
       , h == hP
-        -> blockAtRound h r >>= \case
+        -> retrievePropByR h r >>= \case
              Nothing      -> return peer
              Just (_,bid) -> return $ Current p { peerBlocks = Set.insert bid (peerBlocks p) }
       | otherwise -> return peer


### PR DESCRIPTION
- Remove unused method
- Slightly rework API. Instead of exposing full map expose only block lookup by round and by ID

Initially I tried to remove `m` type parameter by using rank-2 types but they didn't interact well witt `Writable` type family