### PR TITLE
Make transaction type a TF from block type

### DIFF
--- a/thundermint/Thundermint/Blockchain/Internal/Engine.hs
+++ b/thundermint/Thundermint/Blockchain/Internal/Engine.hs
@@ -58,8 +58,7 @@ newAppChans = do
 --
 --   * INVARIANT: Only this function can write to blockchain
 runApplication
-  :: ( MonadIO m, MonadCatch m, MonadLogger m, Crypto alg
-     , Serialise a, Show a, LogBlock a)
+  :: ( MonadIO m, MonadCatch m, MonadLogger m, Crypto alg, Show a, BlockData a)
   => Configuration
      -- ^ Configuration
   -> AppState m alg a
@@ -87,8 +86,7 @@ runApplication config appSt@AppState{..} appCh@AppChans{..} = logOnException $ d
 --
 -- FIXME: we should write block and last commit in transaction!
 decideNewBlock
-  :: ( MonadIO m, MonadLogger m, Crypto alg
-     , Serialise a, Show a, LogBlock a)
+  :: ( MonadIO m, MonadLogger m, Crypto alg, Show a, BlockData a)
   => Configuration
   -> AppState m alg a
   -> AppChans m alg a

--- a/thundermint/Thundermint/Blockchain/Interpretation.hs
+++ b/thundermint/Thundermint/Blockchain/Interpretation.hs
@@ -32,8 +32,8 @@ import Thundermint.Blockchain.Types
 --   wallet). Transition functions double as validation functions
 --   e.g. if transaction or block is not valid it will return
 --   @Nothing@.
-data BlockFold s tx a = BlockFold
-  { processTx    :: Height -> tx -> s -> Maybe s
+data BlockFold s a = BlockFold
+  { processTx    :: Height -> TX a -> s -> Maybe s
     -- ^ Try to process single transaction. Nothing indicates that
     --   transaction is invalid. This function will called very
     --   frequently so it need not to perform every check but should
@@ -43,7 +43,7 @@ data BlockFold s tx a = BlockFold
   , processBlock :: Height -> a  -> s -> Maybe s
     -- ^ Try to process whole block. Here application should perform
     --   complete validation of block
-  , transactionsToBlock :: Height -> s -> [tx] -> a
+  , transactionsToBlock :: Height -> s -> [TX a] -> a
     -- ^ Create block at given height from list of transactions. Not
     --   input could contain invalid transaction and they must be
     --   filtered out so that block is valid.
@@ -66,7 +66,7 @@ data BChState m s = BChState
 -- | Create block storage backed by MVar
 newBChState
   :: (MonadMask m, MonadIO m)
-  => BlockFold s tx a           -- ^ Updating function
+  => BlockFold s a             -- ^ Updating function
   -> BlockStorage 'RO m alg a  -- ^ Store of blocks
   -> m (BChState m s)
 newBChState BlockFold{..} BlockStorage{..} = do

--- a/thundermint/Thundermint/Blockchain/Types.hs
+++ b/thundermint/Thundermint/Blockchain/Types.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE TypeFamilies               #-}
 -- |
 -- Data types for implementation of consensus algorithm
 module Thundermint.Blockchain.Types (
@@ -18,6 +19,7 @@ module Thundermint.Blockchain.Types (
   , Block(..)
   , Header(..)
   , Commit(..)
+  , BlockData(..)
     -- * Data types for establishing consensus
   , Step(..)
   , FullStep(..)
@@ -123,6 +125,19 @@ data Commit alg a = Commit
   deriving (Show, Eq, Generic)
 instance Serialise (Commit alg a)
 
+
+-- | Type class for data which could be put into block
+class (Serialise a, Serialise (TX a)) => BlockData a where
+  -- | Transaction type of block
+  type TX a
+  -- | Return list of transaction in block
+  blockTransactions :: a -> [TX a]
+  logBlockData      :: a -> JSON.Object
+
+instance (Serialise a) => BlockData [a] where
+  type TX [a] = a
+  blockTransactions = id
+  logBlockData      = HM.singleton "Ntx" . JSON.toJSON . length
 
 
 ----------------------------------------------------------------

--- a/thundermint/Thundermint/Logger.hs
+++ b/thundermint/Thundermint/Logger.hs
@@ -28,7 +28,6 @@ module Thundermint.Logger (
   , Verbosity(..)
     -- * Structured logging
   , LogBlockInfo(..)
-  , LogBlock(..)
   ) where
 
 import Control.Arrow (first,second)
@@ -41,7 +40,6 @@ import Control.Monad.Trans.Maybe  (MaybeT(..))
 import Control.Exception          (SomeException(..),AsyncException(..))
 import Data.Aeson
 import Data.Aeson.TH
-import Data.Int
 import Data.IORef
 import Data.Text       (Text)
 import Data.Typeable
@@ -243,23 +241,14 @@ makeEsUrlScribe serverPath sev verb = do
 -- LogBlock
 ----------------------------------------------------------------
 
--- | Type class for providing logging information about block
-class LogBlock a where
-  logBlockData :: a -> Object
-  logBlockData _ = HM.empty
-
-instance LogBlock Int64
-instance LogBlock [a] where
-  logBlockData txs = HM.singleton "Ntx" (toJSON (length txs))
-
 -- | Wrapper for log data for logging purposes
 data LogBlockInfo a = LogBlockInfo Height a
 
-instance LogBlock a => ToObject (LogBlockInfo a) where
+instance BlockData a => ToObject (LogBlockInfo a) where
   toObject (LogBlockInfo (Height h) a)
     = HM.insert "H" (toJSON h)
     $ logBlockData a
 
-instance LogBlock a => LogItem (LogBlockInfo a) where
+instance BlockData a => LogItem (LogBlockInfo a) where
   payloadKeys Katip.V0 _ = Katip.SomeKeys ["H"]
   payloadKeys _        _ = Katip.AllKeys

--- a/thundermint/Thundermint/Mock/Coin.hs
+++ b/thundermint/Thundermint/Mock/Coin.hs
@@ -108,7 +108,7 @@ processTransaction transaction@(Send pubK sig txSend@TxSend{..}) CoinState{..} =
         in add $ spend unspentOutputs
     }
 
-transitions :: BlockFold CoinState Tx [Tx]
+transitions :: BlockFold CoinState [Tx]
 transitions = BlockFold
   { processTx           = process
   , processBlock        = \h txs s0 -> foldM (flip (process h)) s0 txs

--- a/thundermint/Thundermint/Mock/KeyVal.hs
+++ b/thundermint/Thundermint/Mock/KeyVal.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TupleSections     #-}
-
 -- |
 module Thundermint.Mock.KeyVal (
     genesisBlock
@@ -59,7 +58,7 @@ genesisBlock valSet = Block
   , blockLastCommit = Nothing
   }
 
-transitions :: BlockFold (Map String Int) (String,Int) [(String,Int)]
+transitions :: BlockFold (Map String Int) [(String,Int)]
 transitions = BlockFold
   { processTx           = const process
   , processBlock        = \_ txs s0 -> foldM (flip process) s0 txs
@@ -137,7 +136,7 @@ interpretSpec maxH prefix NetSpec{..} = do
                        (map (,"50000") $ connections netAddresses addr)
                        appCh
                        (hoistBlockStorageRO liftIO $ makeReadOnly storage)
-                       nullMempool
+                       nullMempoolAny
                  , setNamespace "consensus"
                    $ runApplication defCfg appState appCh
                  ]

--- a/thundermint/Thundermint/P2P.hs
+++ b/thundermint/Thundermint/P2P.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE NumDecimals         #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
 {-# LANGUAGE TemplateHaskell     #-}
 -- |
 -- Mock P2P
@@ -64,17 +66,17 @@ import Thundermint.Utils
 --
 --   FIXME: We don't have good way to prevent DoS by spamming too much
 --          data
-data GossipMsg tx addr alg a
+data GossipMsg addr alg a
   = GossipPreVote   (Signed 'Unverified alg (Vote 'PreVote   alg a))
   | GossipPreCommit (Signed 'Unverified alg (Vote 'PreCommit alg a))
   | GossipProposal  (Signed 'Unverified alg (Proposal alg a))
   | GossipBlock     (Block alg a)
   | GossipAnn       (Announcement alg)
-  | GossipTx        tx
+  | GossipTx        (TX a)
   | GossipPex       (PexMessage addr)
-  deriving (Show, Generic)
-
-instance (Serialise tx, Serialise addr, Serialise a) => Serialise (GossipMsg tx addr alg a)
+  deriving (Generic)
+deriving instance (Show a, Show addr, Show (TX a)) => Show (GossipMsg addr alg a)
+instance (Serialise (TX a), Serialise addr, Serialise a) => Serialise (GossipMsg addr alg a)
 
 
 -- | Peer exchage gossip sub-message
@@ -178,14 +180,14 @@ readRecv (Counter _ r) = liftIO $ readMVar r
 --   of nodes and gossip.
 startPeerDispatcher
   :: ( MonadMask m, MonadFork m, MonadLogger m, MonadTrace m
-     , Serialise a, Serialise tx, Ord addr, Show addr, Serialise addr, Show a, Crypto alg)
+     , BlockData a,  Ord addr, Show addr, Serialise addr, Show a, Crypto alg)
   => Configuration
   -> NetworkAPI addr          -- ^ API for networking
   -> addr                     -- ^ Current peer address
   -> [addr]                   -- ^ Set of initial addresses to connect
   -> AppChans m alg a         -- ^ Channels for communication with main application
   -> BlockStorage 'RO m alg a -- ^ Read only access to block storage
-  -> Mempool m alg tx
+  -> Mempool m alg (TX a)
   -> m ()
 startPeerDispatcher p2pConfig net peerAddr addrs AppChans{..} storage mempool = logOnException $ do
   peerId <- generatePeerId
@@ -265,11 +267,11 @@ retryPolicy = exponentialBackoff 100000 <> limitRetries 5
 -- Thread which accepts connections from remote nodes
 acceptLoop
   :: ( MonadFork m, MonadMask m, MonadLogger m, MonadTrace m
-     , Serialise a, Serialise tx, Ord addr, Show addr, Serialise addr, Show a, Crypto alg)
+     , BlockData a, Ord addr, Show addr, Serialise addr, Show a, Crypto alg)
   => addr
   -> NetworkAPI addr
   -> PeerChans m addr alg a
-  -> Mempool m alg tx
+  -> Mempool m alg (TX a)
   -> PeerRegistry addr
   -> m ()
 acceptLoop peerAddr NetworkAPI{..} peerCh mempool peerRegistry = do
@@ -310,13 +312,13 @@ acceptLoop peerAddr NetworkAPI{..} peerCh mempool peerRegistry = do
 -- Initiate connection to remote host and register peer
 connectPeerTo
   :: ( MonadFork m, MonadMask m, MonadLogger m, MonadTrace m
-     , Ord addr, Serialise a, Serialise tx, Show addr, Serialise addr, Show a, Crypto alg
+     , Ord addr, BlockData a, Show addr, Serialise addr, Show a, Crypto alg
      )
   => addr
   -> NetworkAPI addr
   -> addr
   -> PeerChans m addr alg a
-  -> Mempool m alg tx
+  -> Mempool m alg (TX a)
   -> PeerRegistry addr
   -> m ()
 connectPeerTo peerAddr NetworkAPI{..} addr peerCh mempool peerRegistry =
@@ -482,11 +484,11 @@ peerPexKnownCapacityMonitor _peerAddr PeerChans{..} PeerRegistry{..} minKnownCon
 
 peerPexMonitor
   :: ( MonadFork m, MonadMask m, MonadLogger m, MonadTrace m
-     , Serialise a, Serialise tx, Ord addr, Show addr, Serialise addr, Show a, Crypto alg)
+     , BlockData a, Ord addr, Show addr, Serialise addr, Show a, Crypto alg)
   => addr -- ^ Current peer address for logging purpose
   -> NetworkAPI addr
   -> PeerChans m addr alg a
-  -> Mempool m alg tx
+  -> Mempool m alg (TX a)
   -> PeerRegistry addr
   -> Int
   -> Int
@@ -530,7 +532,7 @@ peerGossipPeerExchange
   -> PeerChans m addr alg a
   -> PeerRegistry addr
   -> TChan (PexMessage addr)
-  -> TBQueue (GossipMsg tx addr alg a)
+  -> TBQueue (GossipMsg addr alg a)
   -> m ()
 peerGossipPeerExchange _peerAddr PeerChans{..} PeerRegistry{prConnected,prIsActive} pexCh gossipCh = forever $
     liftIO (atomically $ readTChan pexCh) >>= \case
@@ -570,14 +572,14 @@ peerGossipPeerExchange _peerAddr PeerChans{..} PeerRegistry{prConnected,prIsActi
 --   established and peer is registered.
 startPeer
   :: ( MonadFork m, MonadMask m, MonadLogger m
-     , Show a, Serialise a, Serialise addr, Show addr, Ord addr, Serialise tx, Crypto alg)
+     , Show a, BlockData a, Serialise addr, Show addr, Ord addr, Crypto alg)
   => addr
   -> addr
   -> PeerChans m addr alg a  -- ^ Communication with main application
                              --   and peer dispatcher
   -> Connection              -- ^ Functions for interaction with network
   -> PeerRegistry addr
-  -> Mempool m alg tx
+  -> Mempool m alg (TX a)
   -> m ()
 startPeer peerAddrFrom peerAddrTo peerCh@PeerChans{..} conn peerRegistry mempool = logOnException $ do
   logger InfoS "Starting peer" ()
@@ -602,7 +604,7 @@ peerGossipVotes
   :: (MonadIO m, MonadFork m, MonadMask m, MonadLogger m, Crypto alg)
   => PeerStateObj m alg a         -- ^ Current state of peer
   -> PeerChans m addr alg a       -- ^ Read-only access to
-  -> TBQueue (GossipMsg tx addr alg a)
+  -> TBQueue (GossipMsg addr alg a)
   -> m x
 peerGossipVotes peerObj PeerChans{..} gossipCh = logOnException $ do
   logger InfoS "Starting routine for gossiping votes" ()
@@ -692,8 +694,8 @@ peerGossipMempool
   => PeerStateObj m alg a
   -> PeerChans m addr alg a
   -> Configuration
-  -> TBQueue (GossipMsg tx addr alg a)
-  -> MempoolCursor m alg tx
+  -> TBQueue (GossipMsg addr alg a)
+  -> MempoolCursor m alg (TX a)
   -> m x
 peerGossipMempool peerObj PeerChans{..} config gossipCh MempoolCursor{..} = logOnException $ do
   logger InfoS "Starting routine for gossiping transactions" ()
@@ -712,7 +714,7 @@ peerGossipBlocks
   :: (MonadIO m, MonadFork m, MonadMask m, MonadLogger m)
   => PeerStateObj m alg a       -- ^ Current state of peer
   -> PeerChans m addr alg a     -- ^ Read-only access to
-  -> TBQueue (GossipMsg tx addr alg a) -- ^ Network API
+  -> TBQueue (GossipMsg addr alg a) -- ^ Network API
   -> m x
 peerGossipBlocks peerObj PeerChans{..} gossipCh = logOnException $ do
   logger InfoS "Starting routine for gossiping votes" ()
@@ -749,12 +751,12 @@ peerGossipBlocks peerObj PeerChans{..} gossipCh = logOnException $ do
 -- | Routine for receiving messages from peer
 peerReceive
   :: ( MonadIO m, MonadFork m, MonadMask m, MonadLogger m
-     , Serialise addr, Crypto alg, Serialise a, Serialise tx)
+     , Serialise addr, Crypto alg, BlockData a)
   => PeerStateObj m alg a
   -> PeerChans m addr alg a
   -> TChan (PexMessage addr)
   -> Connection
-  -> MempoolCursor m alg tx
+  -> MempoolCursor m alg (TX a)
   -> m ()
 peerReceive peerSt PeerChans{..} peerExchangeCh Connection{..} MempoolCursor{..} = logOnException $ do
   logger InfoS "Starting routing for receiving messages" ()
@@ -795,7 +797,7 @@ peerReceive peerSt PeerChans{..} peerExchangeCh Connection{..} MempoolCursor{..}
 
 -- | Dump GossipMsg without (Show) constraints
 --
-showlessShowGossipMsg :: (Show addr) => GossipMsg tx addr alg a -> Katip.LogStr
+showlessShowGossipMsg :: (Show addr) => GossipMsg addr alg a -> Katip.LogStr
 showlessShowGossipMsg (GossipPreVote _)   = "GossipPreVote ..."
 showlessShowGossipMsg (GossipPreCommit _) = "GossipPreCommit ..."
 showlessShowGossipMsg (GossipProposal _)  = "GossipProposal ..."
@@ -808,12 +810,12 @@ showlessShowGossipMsg (GossipPex p)       = "GossipPex { " <> showLS p <> " }"
 -- | Routine for actually sending data to peers
 peerSend
   :: ( MonadIO m, MonadFork m, MonadMask m, MonadLogger m
-     , Crypto alg, Serialise addr, Show addr, Serialise a, Serialise tx)
+     , Crypto alg, Serialise addr, Show addr, BlockData a)
   => addr
   -> addr
   -> PeerStateObj m alg a
   -> PeerChans m addr alg a
-  -> TBQueue (GossipMsg tx addr alg a)
+  -> TBQueue (GossipMsg addr alg a)
   -> Connection
   -> m x
 peerSend _peerAddrFrom peerAddrTo peerSt PeerChans{..} gossipCh Connection{..} = logOnException $ do

--- a/thundermint/Thundermint/Run.hs
+++ b/thundermint/Thundermint/Run.hs
@@ -46,14 +46,14 @@ import Thundermint.Control (MonadFork)
 ----------------------------------------------------------------
 
 -- | Specification of node
-data NodeDescription m alg st tx a = NodeDescription
-  { nodeBlockChainLogic :: BlockFold st tx a
+data NodeDescription m alg st a = NodeDescription
+  { nodeBlockChainLogic :: BlockFold st a
     -- ^ Logic of blockchain
   , nodeStorage         :: BlockStorage 'RW m alg a
     -- ^ Storage for commited blocks
   , nodeBchState        :: BChState m st
     -- ^ Current state of blockchain
-  , nodeMempool         :: Mempool m alg tx
+  , nodeMempool         :: Mempool m alg (TX a)
     -- ^ Mempool of node
   , nodeValidationKey   :: Maybe (PrivValidator alg)
     -- ^ Private key of validator
@@ -70,12 +70,11 @@ data BlockchainNet addr = BlockchainNet
 
 runNode
   :: ( MonadMask m, MonadFork m, MonadLogger m, MonadTrace m
-     , Serialise tx
-     , Crypto alg, Ord addr, Show addr, Serialise addr, Show a, LogBlock a
-     , Serialise a)
+     , Crypto alg, Ord addr, Show addr, Serialise addr, Show a, BlockData a
+     )
   => Configuration
   -> BlockchainNet addr
-  -> NodeDescription m alg st tx a
+  -> NodeDescription m alg st a
   -> m [m ()]
 runNode cfg BlockchainNet{..} NodeDescription{nodeBlockChainLogic=BlockFold{..}, ..} = do
   -- Create state of blockchain & Update it to current state of


### PR DESCRIPTION
1. Introduce type class for data that could serve as block data 

2. Transaction type is type family from block data type. Main reason for this is to remove one type parameter from signatures since if we know type of data we should know type of transaction as well
