### PR TITLE
Fix computation of key fingerprint for GHCJS

### DIFF
--- a/thundermint-crypto/ghcjs/Thundermint/Crypto/Ed25519.hs
+++ b/thundermint-crypto/ghcjs/Thundermint/Crypto/Ed25519.hs
@@ -8,7 +8,9 @@ module Thundermint.Crypto.Ed25519 (
 import Control.Monad
 import Data.ByteString (ByteString)
 import Data.Ord        (comparing)
-import qualified Data.ByteString as BS
+import qualified Data.ByteString      as BS
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Digest.Pure.SHA as SHA
 
 import GHCJS.Buffer
 import GHCJS.Types
@@ -43,7 +45,9 @@ instance Crypto Ed25519_SHA512 where
     = js_sign_detached_verify (bsToArray blob) (bsToArray s) pubKey
   --
   publicKey = PublicKey . pubK
-  address   = Address . arrayToBs . js_sha512 . unPublicKey
+  address   = Address
+            . BL.toStrict . SHA.bytestringDigest . SHA.sha256 . BL.fromStrict
+            . arrayToBs . js_sha512 . unPublicKey
   hashBlob  = Hash . arrayToBs . js_sha512 . bsToArray
   --
   privKeyFromBS bs = do

--- a/thundermint-crypto/thundermint-crypto.cabal
+++ b/thundermint-crypto/thundermint-crypto.cabal
@@ -28,6 +28,7 @@ Library
     hs-source-dirs: ghcjs .
     Build-depends:     ghcjs-prim
                      , ghcjs-base
+                     , SHA               >=1.6 && <2
   else
     hs-source-dirs: ghc .
     Build-Depends:     cryptonite        >=0.25
@@ -50,7 +51,8 @@ Test-suite thundermint-crypto-tests
                      , serialise         >=0.2
                      --
                      , tasty             >=0.11
-                     , tasty-hunit       >=0.10
+                     -- Contains fix for GHCJS
+                     , tasty-hunit       >=0.10.0.1
   hs-source-dirs:      test
   Main-is:             Main.hs
   Other-modules:       TM.Crypto


### PR DESCRIPTION
for computation of SHA256 pure haskell implementation from `SHA` package is used