### PR TITLE
Make all datastructure's fields strict.

### DIFF
--- a/thundermint/Thundermint/Blockchain/Internal/Engine.hs
+++ b/thundermint/Thundermint/Blockchain/Internal/Engine.hs
@@ -216,10 +216,10 @@ newtype ConsensusM alg a m b = ConsensusM
   deriving (Functor)
 
 data ConsensusResult alg a b
-  = Success b
+  = Success !b
   | Tranquility
   | Misdeed
-  | DoCommit  (Commit alg a) (TMState alg a)
+  | DoCommit  !(Commit alg a) !(TMState alg a)
   deriving (Functor)
 
 instance Monad m => Applicative (ConsensusM alg a m) where

--- a/thundermint/Thundermint/Blockchain/Internal/Engine/Types.hs
+++ b/thundermint/Thundermint/Blockchain/Internal/Engine/Types.hs
@@ -41,17 +41,17 @@ import Thundermint.Store
 --   timeout and second is increment. Unit of measurements for time is
 --   ms.
 data Configuration = Configuration
-  { timeoutNewHeight :: (Int,Int)
-  , timeoutProposal  :: (Int,Int)
-  , timeoutPrevote   :: (Int,Int)
-  , timeoutPrecommit :: (Int,Int)
-  , gossipDelayVotes :: Int
-  , gossipDelayBlocks :: Int
-  , gossipDelayMempool :: Int
-  , pexMinConnections :: Int
-  , pexMaxConnections :: Int
-  , pexMinKnownConnections :: Int
-  , pexMaxKnownConnections :: Int
+  { timeoutNewHeight :: !(Int,Int)
+  , timeoutProposal  :: !(Int,Int)
+  , timeoutPrevote   :: !(Int,Int)
+  , timeoutPrecommit :: !(Int,Int)
+  , gossipDelayVotes :: !Int
+  , gossipDelayBlocks :: !Int
+  , gossipDelayMempool :: !Int
+  , pexMinConnections :: !Int
+  , pexMaxConnections :: !Int
+  , pexMinKnownConnections :: !Int
+  , pexMaxKnownConnections :: !Int
   }
   deriving (Show,Generic)
 instance JSON.FromJSON Configuration

--- a/thundermint/Thundermint/Blockchain/Types.hs
+++ b/thundermint/Thundermint/Blockchain/Types.hs
@@ -85,9 +85,9 @@ type BlockID alg a = BlockHash alg (Block alg a)
 
 -- | Block data type
 data Block alg a = Block
-  { blockHeader     :: Header alg a
-  , blockData       :: a
-  , blockLastCommit :: Maybe (Commit alg a)
+  { blockHeader     :: !(Header alg a)
+  , blockData       :: !a
+  , blockLastCommit :: !(Maybe (Commit alg a))
     -- ^ Commit information for previous block. Nothing iff block
     --   is a genesis block or block at height 1.
   }
@@ -96,16 +96,16 @@ instance Serialise a => Serialise (Block alg a)
 
 -- | Block header
 data Header alg a = Header
-  { headerChainID        :: ByteString
+  { headerChainID        :: !ByteString
     -- ^ Identifier of chain we're working on. It should be same in
     --   all blocks in blockchain
-  , headerHeight         :: Height
+  , headerHeight         :: !Height
     -- ^ Height of block
-  , headerTime           :: Time
+  , headerTime           :: !Time
     -- ^ Time of block creation
-  , headerLastBlockID    :: Maybe (BlockID alg a)
+  , headerLastBlockID    :: !(Maybe (BlockID alg a))
     -- ^ Hash of previous block. Nothing iff block is a genesis block
-  , headerValidatorsHash :: Hash alg
+  , headerValidatorsHash :: !(Hash alg)
     -- ^ Hash of validators for current block.
 
   -- FIXME: Add various hashes
@@ -117,9 +117,9 @@ instance Serialise (Header alg a)
 
 -- | Data justifying commit
 data Commit alg a = Commit
-  { commitBlockID    :: BlockID alg a
+  { commitBlockID    :: !(BlockID alg a)
     -- ^ Block for which commit is done
-  , commitPrecommits :: [Signed 'Verified alg (Vote 'PreCommit alg a)]
+  , commitPrecommits :: !([Signed 'Verified alg (Vote 'PreCommit alg a)])
     -- ^ List of precommits which justify commit
   }
   deriving (Show, Eq, Generic)
@@ -166,24 +166,24 @@ data FullStep = FullStep !Height !Round !Step
   deriving (Show,Eq,Ord,Generic)
 instance Serialise FullStep
 
-data Timeout = Timeout Height Round Step
+data Timeout = Timeout !Height !Round !Step
   deriving (Show,Eq,Ord,Generic)
 instance Serialise Timeout
 
 -- | Proposal for new block. Proposal include only hash of block and
 --   block itself is gossiped separately.
 data Proposal alg a = Proposal
-  { propHeight    :: Height
+  { propHeight    :: !Height
     -- ^ Proposal height
-  , propRound     :: Round
+  , propRound     :: !Round
     -- ^ Propoasl round
-  , propTimestamp :: Time
+  , propTimestamp :: !Time
     -- ^ Time of proposal
-  , propPOL       :: Maybe Round
+  , propPOL       :: !(Maybe Round)
     -- ^ Proof of Lock for proposal
     --
     -- FIXME: why it's needed? How should it be used?
-  , propBlockID   :: BlockID alg a
+  , propBlockID   :: !(BlockID alg a)
     -- ^ Hash of proposed block
   }
   deriving (Show,Generic)
@@ -200,10 +200,10 @@ instance Serialise VoteType
 -- | Single vote cast validator. Type of vote is determined by its
 --   type tag
 data Vote (ty :: VoteType) alg a= Vote
-  { voteHeight  :: Height
-  , voteRound   :: Round
-  , voteTime    :: Time
-  , voteBlockID :: Maybe (BlockID alg a)
+  { voteHeight  :: !Height
+  , voteRound   :: !Round
+  , voteTime    :: !Time
+  , voteBlockID :: !(Maybe (BlockID alg a))
   }
   deriving (Show,Eq,Ord,Generic)
 
@@ -260,19 +260,19 @@ instance JSON.FromJSON ProposalState
 
 -- | State for tendermint consensus at some particular height.
 data TMState alg a = TMState
-  { smRound         :: Round
+  { smRound         :: !Round
     -- ^ Current round
-  , smStep          :: Step
+  , smStep          :: !Step
     -- ^ Current step in the round
-  , smProposals     :: Map Round (Signed 'Verified alg (Proposal alg a))
+  , smProposals     :: !(Map Round (Signed 'Verified alg (Proposal alg a)))
     -- ^ Proposal for current round
-  , smPrevotesSet   :: HeightVoteSet 'PreVote alg a
+  , smPrevotesSet   :: !(HeightVoteSet 'PreVote alg a)
     -- ^ Set of all received valid prevotes
-  , smPrecommitsSet :: HeightVoteSet 'PreCommit alg a
+  , smPrecommitsSet :: !(HeightVoteSet 'PreCommit alg a)
     -- ^ Set of all received valid precommits
-  , smLockedBlock   :: Maybe (Round, BlockID alg a)
+  , smLockedBlock   :: !(Maybe (Round, BlockID alg a))
     -- ^ Round and block we're locked on
-  , smLastCommit    :: Maybe (Commit alg a)
+  , smLastCommit    :: !(Maybe (Commit alg a))
     -- ^ Commit for previous block. Nothing if previous block is
     --   genesis block.
   }

--- a/thundermint/Thundermint/Crypto/Containers.hs
+++ b/thundermint/Thundermint/Crypto/Containers.hs
@@ -64,8 +64,8 @@ import Thundermint.Crypto
 
 -- | Information about remote validator
 data Validator alg = Validator
-  { validatorPubKey      :: PublicKey alg
-  , validatorVotingPower :: Integer
+  { validatorPubKey      :: !(PublicKey alg)
+  , validatorVotingPower :: !Integer
   }
   deriving (Generic)
 deriving instance Eq (PublicKey alg) => Eq (Validator alg)
@@ -170,9 +170,9 @@ emptyValidatorISet n
 --   one value per signature is allowed. Lookup is supported both by
 --   values and by signer's address.
 data SignedSet ty alg a = SignedSet
-  { vsetAddrMap    :: Map (Address alg) (Signed ty alg a)
-  , vsetValMap     :: Map a (Set (Address alg))
-  , vsetValidators :: ValidatorSet alg
+  { vsetAddrMap    :: !(Map (Address alg) (Signed ty alg a))
+  , vsetValMap     :: !(Map a (Set (Address alg)))
+  , vsetValidators :: !(ValidatorSet alg)
   }
 
 instance (Show a) => Show (SignedSet ty alg a) where
@@ -180,10 +180,10 @@ instance (Show a) => Show (SignedSet ty alg a) where
 
 -- | Result of insertion into 'SignedSet'
 data InsertResult b a
-  = InsertOK       a            -- ^ Insert is successful
+  = InsertOK       !a            -- ^ Insert is successful
   | InsertDup                   -- ^ Duplicate value. No change
-  | InsertConflict b            -- ^ Conflict during insertion
-  | InsertUnknown  b            -- ^ Value is signed by unknown validator
+  | InsertConflict !b            -- ^ Conflict during insertion
+  | InsertUnknown  !b            -- ^ Value is signed by unknown validator
   deriving (Show,Functor)
 
 instance Applicative (InsertResult b) where
@@ -269,8 +269,8 @@ any23 SignedSet{..}
 -- | Map from @r@ to @SignedSet ty alg a@. It maintains invariant that
 --   all submaps have same distribution of voting power
 data SignedSetMap r ty alg a = SignedSetMap
-  { vmapSubmaps    :: Map r (SignedSet ty alg a)
-  , vmapValidators :: ValidatorSet alg
+  { vmapSubmaps    :: !(Map r (SignedSet ty alg a))
+  , vmapValidators :: !(ValidatorSet alg)
   }
 
 instance (Show a, Show r) => Show (SignedSetMap r ty alg a) where

--- a/thundermint/Thundermint/Debug/Trace.hs
+++ b/thundermint/Thundermint/Debug/Trace.hs
@@ -23,15 +23,15 @@ import Thundermint.Control
 data TraceEvents
     =  TeNodeStarted
     -- ^ Node is started
-    | TeNodeConnectingTo String
+    | TeNodeConnectingTo !String
     -- ^ Node try to connect to other address
-    | TeNodeOtherTryConnect String
+    | TeNodeOtherTryConnect !String
     -- ^ Other node try to connect; if it does not
     --   connected previously then `TeNodeConnected`
     --   event fired
-    | TeNodeOtherConnected String
+    | TeNodeOtherConnected !String
     -- ^ Other node connected successfully
-    | TePeerRegistryChanged (Set String)
+    | TePeerRegistryChanged !(Set String)
     deriving (Show, Ord, Eq)
 
 class Monad m => MonadTrace m where

--- a/thundermint/Thundermint/Logger.hs
+++ b/thundermint/Thundermint/Logger.hs
@@ -183,12 +183,12 @@ instance FromJSON ScribeType
 
 -- | Description of scribe
 data ScribeSpec = ScribeSpec
-  { scribe'type      :: ScribeType
+  { scribe'type      :: !ScribeType
     -- ^ Type of scribe to use
-  , scribe'path      :: Maybe FilePath
+  , scribe'path      :: !(Maybe FilePath)
     -- ^ Log file if not specified will log to stdout
-  , scribe'severity  :: Severity
-  , scribe'verbosity :: Verbosity
+  , scribe'severity  :: !Severity
+  , scribe'verbosity :: !Verbosity
   }
   deriving (Show,Eq,Ord,Generic)
 deriveJSON defaultOptions
@@ -262,7 +262,7 @@ makeEsUrlScribe serverPath sev verb = do
 ----------------------------------------------------------------
 
 -- | Wrapper for log data for logging purposes
-data LogBlockInfo a = LogBlockInfo Height a
+data LogBlockInfo a = LogBlockInfo !Height !a
 
 instance BlockData a => ToObject (LogBlockInfo a) where
   toObject (LogBlockInfo (Height h) a)

--- a/thundermint/Thundermint/P2P/PeerState.hs
+++ b/thundermint/Thundermint/P2P/PeerState.hs
@@ -97,8 +97,8 @@ getPeerHeight p = do FullStep h _ _ <- getPeerStep p
 -- | Mutable reference to state of peer. It's safe to mutate
 --   concurrently
 data PeerStateObj m alg a = PeerStateObj
-  (ProposalStorage 'RO m alg a)
-  (MVar (PeerState alg a))
+  !(ProposalStorage 'RO m alg a)
+  !(MVar (PeerState alg a))
 
 
 -- | Create new peer state with default state

--- a/thundermint/Thundermint/P2P/Types.hs
+++ b/thundermint/Thundermint/P2P/Types.hs
@@ -39,27 +39,27 @@ type NetworkPort addr = Net.PortNumber
 --   to provide two implementations of networking. One is real network
 --   and another is mock in-process network for testing.
 data NetworkAPI addr = NetworkAPI
-  { listenOn :: forall m. (MonadIO m, MonadThrow m, MonadMask m)
-             => m (m (), m (Connection , addr))
+  { listenOn :: !(forall m. (MonadIO m, MonadThrow m, MonadMask m)
+             => m (m (), m (Connection , addr)))
     -- ^ Start listening on given port. Returns action to stop listener
     --   and function for accepting new connections
-  , connect  :: forall m. (MonadIO m, MonadThrow m, MonadMask m)
-             => addr -> m Connection
+  , connect  :: !(forall m. (MonadIO m, MonadThrow m, MonadMask m)
+             => addr -> m Connection)
     -- ^ Connect to remote address
-  , filterOutOwnAddresses :: forall m. (MonadIO m, MonadThrow m, MonadMask m)
-             => Set addr -> m (Set addr)
+  , filterOutOwnAddresses :: !(forall m. (MonadIO m, MonadThrow m, MonadMask m)
+             => Set addr -> m (Set addr))
     -- ^ Filter out local addresses of node. Batch processing for speed.
-  , normalizeNodeAddress :: addr -> Maybe (NetworkPort addr) -> addr
+  , normalizeNodeAddress :: !(addr -> Maybe (NetworkPort addr) -> addr)
     -- ^ Normalize address, for example, convert '20.15.10.20:24431' to '20.15.10.20:50000'
-  , listenPort :: NetworkPort addr
+  , listenPort :: !(NetworkPort addr)
   }
 
 data Connection = Connection
-    { send  :: forall m. (MonadIO m) => LBS.ByteString -> m ()
+    { send  :: !(forall m. (MonadIO m) => LBS.ByteString -> m ())
       -- ^ Send data
-    , recv  :: forall m. (MonadIO m) => m (Maybe LBS.ByteString)
+    , recv  :: !(forall m. (MonadIO m) => m (Maybe LBS.ByteString))
       -- ^ Receive data
-    , close :: forall m. (MonadIO m) => m ()
+    , close :: !(forall m. (MonadIO m) => m ())
       -- ^ Close socket
     }
 
@@ -79,9 +79,9 @@ instance Exception NetworkError
 
 -- | Sockets for mock network
 data MockSocket = MockSocket
-  { msckActive :: TVar Bool
-  , msckSend   :: TChan LBS.ByteString
-  , msckRecv   :: TChan LBS.ByteString
+  { msckActive :: !(TVar Bool)
+  , msckSend   :: !(TChan LBS.ByteString)
+  , msckRecv   :: !(TChan LBS.ByteString)
   }
   deriving (Eq)
 

--- a/thundermint/Thundermint/Run.hs
+++ b/thundermint/Thundermint/Run.hs
@@ -81,13 +81,13 @@ instance MonadIO m => MonadDB (DBT 'RW alg a m) alg a where
 ----------------------------------------------------------------
 
 data NodeLogic m alg a = NodeLogic
-  { nodeBlockValidation :: Height -> a -> m Bool
+  { nodeBlockValidation :: !(Height -> a -> m Bool)
     -- ^ Callback used for validation of blocks
-  , nodeCommitQuery     :: Height -> a -> Query 'RW alg a ()
+  , nodeCommitQuery     :: !(Height -> a -> Query 'RW alg a ())
     -- ^ Query for modifying user state.
-  , nodeBlockGenerator  :: Height -> m a
+  , nodeBlockGenerator  :: !(Height -> m a)
     -- ^ Generator for a new block
-  , nodeMempool         :: Mempool m alg (TX a)
+  , nodeMempool         :: !(Mempool m alg (TX a))
     -- ^ Mempool of node
   }
 
@@ -155,18 +155,18 @@ logicFromPersistent PersistentState{..} = do
 
 -- | Specification of node
 data NodeDescription m alg a = NodeDescription
-  { nodeValidationKey   :: Maybe (PrivValidator alg)
+  { nodeValidationKey   :: !(Maybe (PrivValidator alg))
     -- ^ Private key of validator
-  , nodeCommitCallback  :: Height -> m ()
+  , nodeCommitCallback  :: !(Height -> m ())
     -- ^ Callback called immediately after block was commit and user
     --   state in database is updated
   }
 
 -- | Specification of network
 data BlockchainNet addr = BlockchainNet
-  { bchNetwork      :: NetworkAPI addr
-  , bchLocalAddr    :: addr
-  , bchInitialPeers :: [addr]
+  { bchNetwork      :: !(NetworkAPI addr)
+  , bchLocalAddr    :: !addr
+  , bchInitialPeers :: ![addr]
   }
 
 runNode

--- a/thundermint/Thundermint/Store/Internal/Types.hs
+++ b/thundermint/Thundermint/Store/Internal/Types.hs
@@ -17,8 +17,8 @@ import qualified Database.SQLite.Simple.FromField as SQL
 -- | Encoding of haskell value as field in SQLite database
 data FieldEncoding a where
   FieldEncoding :: (SQL.FromField x, SQL.ToField x)
-                => (a -> x)
-                -> (x -> a)
+                => !(a -> x)
+                -> !(x -> a)
                 -> FieldEncoding a
 
 -- | Value is encoded using CBOR and stored in database

--- a/thundermint/Thundermint/Store/SQL.hs
+++ b/thundermint/Thundermint/Store/SQL.hs
@@ -70,7 +70,7 @@ class PersistentData t where
 
 -- | Wrapper for carrying class dictionary with data type
 data Persistent a where
-  PersistentPMap :: PMap k v -> Persistent (PMap k v)
+  PersistentPMap :: !(PMap k v) -> Persistent (PMap k v)
 
 
 -- | Implementation of specific operations for persistent data
@@ -94,9 +94,9 @@ class (ExecutorRO q) => ExecutorRW q where
 
 -- | Map which is persisted on disk
 data PMap k v = PMap
-  { pmapTableName :: Text       -- Name of underlying SQL table
-  , pmapEncodingK :: FieldEncoding k
-  , pmapEncodingV :: FieldEncoding v
+  { pmapTableName :: !Text       -- Name of underlying SQL table
+  , pmapEncodingK :: !(FieldEncoding k)
+  , pmapEncodingV :: !(FieldEncoding v)
   }
 
 instance PersistentData (PMap k v) where
@@ -306,7 +306,7 @@ newtype EphemeralQ alg a dct x = EphemeralQ
   deriving (Functor, Applicative, Monad, Alternative)
 
 data Overlay a where
-  OverlayPMap :: PMap k v -> Map k (Maybe v) -> Overlay (PMap k v)
+  OverlayPMap :: !(PMap k v) -> !(Map k (Maybe v)) -> Overlay (PMap k v)
 
 overlayPMap :: Lens' (Overlay (PMap k v)) (Map k (Maybe v))
 overlayPMap = lens (\(OverlayPMap _ o) -> o) (\(OverlayPMap p _) o -> OverlayPMap p o)


### PR DESCRIPTION
In this commit all the data-datastrures are made strict.
In general it's more safe to keep fields strict for all
datastructures that are not control-structures.
Basically the control structure is a structure that define
evaluation order, can have knots, and basically the one that
has Functor, Foldable, Traversable, Applicative, Alternative, Monad
instances implemented.

So the rule of thumb - if structure doesn't have an instance
for those type-classes - it's a value datastructure and it's
fields should be strict. In general all the fields should be
strict by default unless there is a reason for not doing so.
There are some cases when structure should be lazy, but that
should be explained in comments explicitly.

In general making fields strict gives us two benefits:

   1. It's harder to introduce space leaks, but it's still
      possible to do.

   2. GHC errors out on unset strict fields, but it doesn't
      do that for lazy fields. This increases safety in
      presence of refactors.