### PR TITLE
Validate votes against correct set of validators

### DIFF
--- a/thundermint/Thundermint/Blockchain/Internal/Algorithm.hs
+++ b/thundermint/Thundermint/Blockchain/Internal/Algorithm.hs
@@ -78,6 +78,10 @@ data HeightParameters (m :: * -> *) alg a = HeightParameters
   { currentH             :: !Height
     -- ^ Height we're on.
   , validatorSet         :: !(ValidatorSet alg)
+    -- ^ Validator set for current height
+  , oldValidatorSet      :: !(Maybe (ValidatorSet alg))
+    -- ^ Validator set for previous height. It's used when collecting
+    --   stragglers votes
   , areWeProposers       :: !(Round -> Bool)
     -- ^ Find address of proposer for given round.
   , proposerForRound     :: !(Round -> Address alg)


### PR DESCRIPTION
Height parameter now have field containing set of validators from previous height. Now precommits are validated against correct set of validators. Since we correctly check signatures and avoid duplicates issue with duplicate signatures is finally resolved

Fixes #141 #142 #143 