### PR TITLE
Rework commit callbacks

### DIFF
--- a/thundermint/Thundermint/Mock/KeyVal.hs
+++ b/thundermint/Thundermint/Mock/KeyVal.hs
@@ -124,9 +124,10 @@ interpretSpec maxH prefix NetSpec{..} = do
                            b | Just hM <- maxH
                              , headerHeight (blockHeader b) > Height hM -> throwM Abort
                              | otherwise                                -> return ()
-                       , appCommitQuery      = \_ -> return ()
+                       , appCommitQuery      = SimpleQuery $ \b -> do
+                           Just vset <- retrieveValidatorSet $ headerHeight $ blockHeader b
+                           return vset
                        , appValidator        = nspecPrivKey
-                       , appNextValidatorSet = \_ -> return validatorSet
                        }
                  appCh <- newAppChans
                  runConcurrently


### PR DESCRIPTION
Goal of change is twofold

 1. Finally add support for changing validator set to user code
    Almost all ingredients are here but callback were terrbily
    ugly

 2. Rework callbacks to allow mixing in memory and in DB user
    state.