### PR TITLE
Set step to AwaitCommit on commit

### DIFF
--- a/thundermint/Thundermint/Blockchain/Internal/Algorithm.hs
+++ b/thundermint/Thundermint/Blockchain/Internal/Algorithm.hs
@@ -356,7 +356,8 @@ checkTransitionPrecommit par@HeightParameters{..} r sm@(TMState{..})
          acceptBlock voteRound bid
          commitBlock Commit{ commitBlockID    = bid
                            , commitPrecommits = valuesAtR r smPrecommitsSet
-                           } sm
+                           }
+                     sm { smStep = StepAwaitCommit }
   --  * We have +2/3 precommits for nil at current round
   --  * We are at Precommit step [FIXME?]
   --  => goto Propose(H,R+1)


### PR DESCRIPTION
Before timeouts were working and round was increasing even after
decision to commit was made. It's unlikely that it could lead to problems
except it could possibly confuse gossip. Still it's better to fix it