### PR TITLE
Use good enthropy source for generation of key pair

### DIFF
--- a/thundermint-crypto/thundermint-crypto.cabal
+++ b/thundermint-crypto/thundermint-crypto.cabal
@@ -32,6 +32,7 @@ Library
   else
     hs-source-dirs: ghc .
     Build-Depends:     cryptonite        >=0.25
+                     , entropy           >=0.4
                      , memory            >=0.14.14
   Exposed-modules:
                   Thundermint.Crypto


### PR DESCRIPTION
cryptonite uses hardware RNG as default enthropy source
Its security is somewhat questionable so it's better to use
/dev/urandom and `entropy` package does exactly that