### PR TITLE
WIP: more compact encoding for Commit

### DIFF
--- a/thundermint-types/Thundermint/Types/Validators.hs
+++ b/thundermint-types/Thundermint/Types/Validators.hs
@@ -120,7 +120,7 @@ validatorSetSize = Map.size  . vsValidators
 --
 --   This for example allows to represent validators as bit arrays.
 newtype ValidatorIdx alg = ValidatorIdx Int
-  deriving (Show, Eq, CBOR.Serialise)
+  deriving (Show, Eq, Ord, CBOR.Serialise)
 
 -- | Set of validators where they are represented by their index.
 data ValidatorISet = ValidatorISet !Int !IntSet

--- a/thundermint/Thundermint/P2P.hs
+++ b/thundermint/Thundermint/P2P.hs
@@ -641,23 +641,24 @@ peerGossipVotes peerObj PeerChans{..} gossipCh = logOnException $ do
         --
         case mcmt of
          Just cmt -> do
-           let cmtVotes  = Map.fromList [ (signedAddr v, unverifySignature v)
-                                        | v <- commitPrecommits cmt ]
-               -- FIXME: inefficient
-           let toSet = Set.fromList
-                     . map (address . validatorPubKey)
-                     . mapMaybe (validatorByIndex (lagPeerValidators p))
-                     . getValidatorIntSet
-           let peerVotes = Map.fromSet (const ())
-                         $ toSet (lagPeerPrecommits p)
-               unknown   = Map.difference cmtVotes peerVotes
-           case Map.size unknown of
-             0 -> return ()
-             n -> do i <- liftIO $ randomRIO (0,n-1)
-                     let vote = unverifySignature $ toList unknown !! i
-                     addPrecommit peerObj vote
-                     liftIO $ atomically $ writeTBQueue gossipCh $ GossipPreCommit vote
-                     tickSend cntGossipPrecommit
+           undefined
+           -- let cmtVotes  = Map.fromList [ (signedAddr v, unverifySignature v)
+           --                              | v <- commitPrecommits cmt ]
+           --     -- FIXME: inefficient
+           -- let toSet = Set.fromList
+           --           . map (address . validatorPubKey)
+           --           . mapMaybe (validatorByIndex (lagPeerValidators p))
+           --           . getValidatorIntSet
+           -- let peerVotes = Map.fromSet (const ())
+           --               $ toSet (lagPeerPrecommits p)
+           --     unknown   = Map.difference cmtVotes peerVotes
+           -- case Map.size unknown of
+           --   0 -> return ()
+           --   n -> do i <- liftIO $ randomRIO (0,n-1)
+           --           let vote = unverifySignature $ toList unknown !! i
+           --           addPrecommit peerObj vote
+           --           liftIO $ atomically $ writeTBQueue gossipCh $ GossipPreCommit vote
+           --           tickSend cntGossipPrecommit
          Nothing -> return ()
       --
       Current p -> liftIO (atomically consensusState) >>= \case

--- a/thundermint/Thundermint/Store/Internal/BlockDB.hs
+++ b/thundermint/Thundermint/Store/Internal/BlockDB.hs
@@ -143,9 +143,7 @@ retrieveCommitRound :: (Serialise a) => Height -> Query rw alg a (Maybe Round)
 retrieveCommitRound (Height h) = runMaybeT $ do
   c <-  MaybeT (retrieveCommit (Height h))
     <|> MaybeT (singleQ "SELECT cmt FROM commits WHERE height = ?" (Only h))
-  let getRound (Commit _ (v:_)) = voteRound (signedValue v)
-      getRound _                = error "Impossible"
-  return $ getRound c
+  return $! commitR c
 
 
 -- | Retrieve local commit justifying commit of block as known by


### PR DESCRIPTION
Still a work in progress. This approach allows to make commits much more compact when encoded but creates problem with safecopy approach since we discard original serialized vote and instead rebuild `Vote` structure and recheck its signature

Fixes #242