### PR TITLE
Add ability to configure network parameters

### DIFF
--- a/spec/keyval-stm.json
+++ b/spec/keyval-stm.json
@@ -41,6 +41,6 @@
   ],
   "netTopology"       : "All2All",
   "netInitialDeposit" : 1000,
-  "netInitialKeys"    : 2000
-
+  "netInitialKeys"    : 2000,
+  "netNetCfg"         : {}
 }

--- a/spec/simple-stm.json
+++ b/spec/simple-stm.json
@@ -40,5 +40,6 @@
   ],
   "netTopology"       : "All2All",
   "netInitialDeposit" : 1000,
-  "netInitialKeys"    : 2000
+  "netInitialKeys"    : 2000,
+  "netNetCfg"         : {}
 }

--- a/spec/simple.json
+++ b/spec/simple.json
@@ -44,5 +44,6 @@
   ],
   "netTopology"       : "All2All",
   "netInitialDeposit" : 1000,
-  "netInitialKeys"    : 2000
+  "netInitialKeys"    : 2000,
+  "netNetCfg"         : {}
 }

--- a/thundermint/Thundermint/Mock/Types.hs
+++ b/thundermint/Thundermint/Mock/Types.hs
@@ -78,11 +78,11 @@ data NetSpec a = NetSpec
   , netInitialKeys    :: Int
   , netPrefix         :: Maybe String
   , netMaxH           :: Maybe Int64
+  , netNetCfg         :: Configuration Example
   }
   deriving (Generic,Show)
 
 instance JSON.ToJSON   NodeSpec
 instance JSON.FromJSON NodeSpec
-instance JSON.ToJSON   a => JSON.ToJSON   (NetSpec a)
 instance JSON.FromJSON a => JSON.FromJSON (NetSpec a)
 

--- a/thundermint/spec/keyval-stm.json
+++ b/thundermint/spec/keyval-stm.json
@@ -45,6 +45,6 @@
   ],
   "netTopology"       : "All2All",
   "netInitialDeposit" : 1000,
-  "netInitialKeys"    : 12
-
+  "netInitialKeys"    : 12,
+  "netNetCfg"         : {}
 }


### PR DESCRIPTION
It's part of NetSpec for in-memory networks and passed as
THUNDERMINT_NET_PARAM envvar for thundermint-coin-node