### PR TITLE
Fix metrics for height/round

### DIFF
--- a/thundermint/Thundermint/Blockchain/Internal/Algorithm.hs
+++ b/thundermint/Thundermint/Blockchain/Internal/Algorithm.hs
@@ -218,6 +218,7 @@ newHeight HeightParameters{..} lastCommit = do
   logger InfoS "Entering new height ----------------" (sl "H" currentH)
   scheduleTimeout $ Timeout  currentH (Round 0) StepNewHeight
   announceStep    $ FullStep currentH (Round 0) StepNewHeight
+  updateMetricsHR currentH (Round 0)
   return TMState
     { smRound         = Round 0
     , smStep          = StepNewHeight


### PR DESCRIPTION
Update metric when entering new height as well. It's important when
node is catching up. It may and frequently does commit block before
entering propose phase. Thus node may catch up very quickly but gause
will be left in same state