### PR TITLE
Fix namespace handling in logging

### DIFF
--- a/thundermint/Thundermint/Logger.hs
+++ b/thundermint/Thundermint/Logger.hs
@@ -105,8 +105,8 @@ instance (MonadReadDB m alg a) => MonadReadDB (LoggerT m) alg a where
 instance (MonadDB m alg a) => MonadDB (LoggerT m) alg a where
   askConnectionRW = lift askConnectionRW
 
-runLoggerT :: Namespace -> LogEnv -> LoggerT m a -> m a
-runLoggerT nm le (LoggerT m) = runReaderT m (nm,le)
+runLoggerT :: LogEnv -> LoggerT m a -> m a
+runLoggerT le (LoggerT m) = runReaderT m (mempty, le)
 
 instance MonadIO m => Katip (LoggerT m) where
   getLogEnv = LoggerT $ fmap snd ask

--- a/thundermint/Thundermint/Mock/Coin.hs
+++ b/thundermint/Thundermint/Mock/Coin.hs
@@ -417,7 +417,7 @@ executeNodeSpec maxH delay NetSpec{..} = do
           , bchInitialPeers = map (,"50000") $ connections netAddresses addr
           }
     let loggers = [ makeScribe s | s <- nspecLogFile ]
-        run m   = withLogEnv "TM" "DEV" loggers $ \logenv -> runLoggerT "general" logenv m
+        run m   = withLogEnv "TM" "DEV" loggers $ \logenv -> runLoggerT logenv m
     run $ (fmap . fmap) run $ interpretSpec maxH genSpec validatorSet bnet netNetCfg nspec
   runConcurrently (snd <$> actions) `catch` (\Abort -> return ())
   return $ fst <$> actions

--- a/thundermint/Thundermint/Mock/KeyVal.hs
+++ b/thundermint/Thundermint/Mock/KeyVal.hs
@@ -88,7 +88,7 @@ interpretSpec maxH prefix NetSpec{..} = do
     runDBT conn $ do
       hChain <- queryRO blockchainHeight
       return ( connectionRO conn
-             , runDBT conn $ withLogEnv "TM" "DEV" loggers $ \logenv -> runLoggerT "general" logenv $ do
+             , runDBT conn $ withLogEnv "TM" "DEV" loggers $ \logenv -> runLoggerT logenv $ do
                  -- Blockchain state
                  bchState <- newBChState transitions
                  _        <- stateAtH bchState (succ hChain)

--- a/thundermint/Thundermint/Run.hs
+++ b/thundermint/Thundermint/Run.hs
@@ -182,7 +182,7 @@ runNode cfg BlockchainNet{..} NodeDescription{..} NodeLogic{..} = do
         { appValidationFun  = nodeBlockValidation
         , appBlockGenerator = nodeBlockGenerator
         , appCommitQuery    = nodeCommitQuery
-        , appCommitCallback = \b -> setNamespace "mempool" $ do
+        , appCommitCallback = \b -> descendNamespace "mempool" $ do
             do before <- mempoolStats nodeMempool
                logger InfoS "Mempool before filtering" before
             filterMempool nodeMempool
@@ -195,10 +195,10 @@ runNode cfg BlockchainNet{..} NodeDescription{..} NodeLogic{..} = do
   -- Networking
   appCh <- newAppChans (cfgConsensus cfg)
   return
-    [ id $ setNamespace "net"
+    [ id $ descendNamespace "net"
          $ startPeerDispatcher (cfgNetwork cfg)
               bchNetwork bchLocalAddr bchInitialPeers appCh nodeMempool
-    , id $ setNamespace "consensus"
+    , id $ descendNamespace "consensus"
          $ runApplication (cfgConsensus cfg) nodeReadyCreateBlock appSt appCh
     , forever $ do
         MempoolInfo{..} <- mempoolStats nodeMempool

--- a/thundermint/exe/coin-node.hs
+++ b/thundermint/exe/coin-node.hs
@@ -90,7 +90,7 @@ main = do
                   ]
     let port = 1000 + fromIntegral listenPort
     startWebMonitoring port
-    withLogEnv "TM" "DEV" loggers $ \logenv -> runLoggerT "Coin" logenv $ do
+    withLogEnv "TM" "DEV" loggers $ \logenv -> runLoggerT logenv $ do
       let !validatorSet = makeValidatorSetFromPriv
                         $ (id @[PrivValidator Ed25519_SHA512])
                         $ either error (fmap PrivValidator)


### PR DESCRIPTION
1. Consensus engine needs to enter one level deeper into namespace
   instead of setting it
2. runLoggerT should start in root namespace. Common namespace should
   be provided in LogEnv