### PR TITLE
Fi for block of gossip

### DIFF
--- a/thundermint-types/Thundermint/Types/Blockchain.hs
+++ b/thundermint-types/Thundermint/Types/Blockchain.hs
@@ -263,7 +263,7 @@ data Step
   | StepPrecommit
     -- ^ Precommiting block or NIL and collecting precommits from
     --   other nodes
-  | StepAwaitCommit
+  | StepAwaitCommit !Round
     -- ^ We already reached consensus and now waiting for data to
     --   perform commit. Node could only stay in this state if it
     --   catching up and got all required precommits before getting

--- a/thundermint/Thundermint/Blockchain/Internal/Algorithm.hs
+++ b/thundermint/Thundermint/Blockchain/Internal/Algorithm.hs
@@ -265,11 +265,11 @@ tendermintTransition par@HeightParameters{..} msg sm@TMState{..} =
     ----------------------------------------------------------------
     PreVoteMsg v@(signedValue -> Vote{..})
       -- Only accept votes with current height
-      | voteHeight /= currentH    -> tranquility
+      | voteHeight /= currentH      -> tranquility
       -- If we awaiting commit we don't care about prevotes
-      | smStep == StepAwaitCommit -> tranquility
-      | otherwise                 -> checkTransitionPrevote par voteRound
-                                 =<< addPrevote par v sm
+      | StepAwaitCommit _ <- smStep -> tranquility
+      | otherwise                   -> checkTransitionPrevote par voteRound
+                                   =<< addPrevote par v sm
     ----------------------------------------------------------------
     PreCommitMsg v@(signedValue -> Vote{..})
       -- Collect stragglers precommits for inclusion of
@@ -303,14 +303,14 @@ tendermintTransition par@HeightParameters{..} msg sm@TMState{..} =
         EQ -> do
           case smStep of
             --
-            StepNewHeight   -> needNewBlock par sm >>= \case
+            StepNewHeight     -> needNewBlock par sm >>= \case
               True  -> enterPropose par smRound sm Reason'Timeout
               False -> do scheduleTimeout $ Timeout currentH (Round 0) StepNewHeight
                           return sm
-            StepProposal    -> enterPrevote   par smRound        sm Reason'Timeout
-            StepPrevote     -> enterPrecommit par smRound        sm Reason'Timeout
-            StepPrecommit   -> enterPropose   par (succ smRound) sm Reason'Timeout
-            StepAwaitCommit -> tranquility
+            StepProposal      -> enterPrevote   par smRound        sm Reason'Timeout
+            StepPrevote       -> enterPrecommit par smRound        sm Reason'Timeout
+            StepPrecommit     -> enterPropose   par (succ smRound) sm Reason'Timeout
+            StepAwaitCommit _ -> tranquility
       where
         t0 = Timeout currentH smRound smStep
 
@@ -376,7 +376,7 @@ checkTransitionPrecommit par@HeightParameters{..} r sm@(TMState{..})
          commitBlock Commit{ commitBlockID    = bid
                            , commitPrecommits = valuesAtR r smPrecommitsSet
                            }
-                     sm { smStep = StepAwaitCommit }
+                     sm { smStep = StepAwaitCommit r }
   --  * We have +2/3 precommits for nil at current round
   --  * We are at Precommit step [FIXME?]
   --  => goto Propose(H,R+1)

--- a/thundermint/Thundermint/Blockchain/Internal/Engine.hs
+++ b/thundermint/Thundermint/Blockchain/Internal/Engine.hs
@@ -350,11 +350,11 @@ makeHeightParameters ConsensusCfg{..} ready AppState{..} AppChans{..} = do
     , scheduleTimeout = \t@(Timeout _ (Round r) step) ->
         liftIO $ void $ forkIO $ do
           let (baseT,delta) = case step of
-                StepNewHeight -> timeoutNewHeight
-                StepProposal  -> timeoutProposal
-                StepPrevote   -> timeoutPrevote
-                StepPrecommit -> timeoutPrecommit
-                StepAwaitCommit -> (0, 0)
+                StepNewHeight     -> timeoutNewHeight
+                StepProposal      -> timeoutProposal
+                StepPrevote       -> timeoutPrevote
+                StepPrecommit     -> timeoutPrecommit
+                StepAwaitCommit _ -> (0, 0)
           threadDelay $ 1000 * (baseT + delta * fromIntegral r)
           atomically $ writeTQueue appChanRxInternal $ RxTimeout t
     --

--- a/thundermint/Thundermint/P2P.hs
+++ b/thundermint/Thundermint/P2P.hs
@@ -837,6 +837,9 @@ peerGossipAnnounce PeerChans{..} gossipCh = logOnException $
       st <- consensusState
       forM_ st $ \(h,TMState{smRound,smStep}) -> do
         writeTBQueue gossipCh $ GossipAnn $ AnnStep $ FullStep h smRound smStep
+        case smStep of
+          StepAwaitCommit r -> writeTBQueue gossipCh $ GossipAnn $ AnnHasProposal h r
+          _                 -> return ()
     waitSec 10
 
 ---- | Dump GossipMsg without (Show) constraints


### PR DESCRIPTION
If node starts with all required votes in WAL to decide on block but doesn't have block itself it will lock up. It enters StepAwaitCommit before it has chance to communicate with peers