### PR TITLE
Make hashes used in mempool type-indexed

### DIFF
--- a/thundermint/Thundermint/Store.hs
+++ b/thundermint/Thundermint/Store.hs
@@ -267,7 +267,7 @@ instance Katip.LogItem  MempoolInfo where
 
 -- | Cursor into mempool which is used for gossiping data
 data MempoolCursor m alg tx = MempoolCursor
-  { pushTransaction :: !(tx -> m (Maybe (Hash alg)))
+  { pushTransaction :: !(tx -> m (Maybe (Hashed alg tx)))
     -- ^ Add transaction to the mempool. It's preliminary checked and
     --   if check fails it immediately discarded. If transaction is
     --   accepted its hash is computed and returned
@@ -287,7 +287,7 @@ data Mempool m alg tx = Mempool
     -- ^ Remove transactions that are no longer valid from mempool
   , getMempoolCursor  :: !(m (MempoolCursor m alg tx))
     -- ^ Get cursor pointing to be
-  , txInMempool       :: !(Hash alg -> m Bool)
+  , txInMempool       :: !(Hashed alg tx -> m Bool)
     -- ^ Checks whether transaction is mempool
   , mempoolStats      :: !(m MempoolInfo)
     -- ^ Number of elements in mempool

--- a/thundermint/Thundermint/Store/STM.hs
+++ b/thundermint/Thundermint/Store/STM.hs
@@ -117,7 +117,7 @@ newMempool validation = do
           modifyTVar' varRevMap $ \m0 ->
             foldl' (\m (_,tx) -> Map.delete tx m) m0 invalidTx
           modifyTVar' varTxSet  $ \s0 ->
-            foldl' (\s(_,tx) -> Set.delete (hash tx) s) s0 invalidTx
+            foldl' (\s(_,tx) -> Set.delete (hashed tx) s) s0 invalidTx
           modifyTVar' varFiltered (+ (length invalidTx))
     --
     , mempoolStats = liftIO $ atomically $ do
@@ -146,7 +146,7 @@ newMempool validation = do
                 rmap <- readTVar varRevMap
                 case tx `Map.notMember` rmap of
                   True -> do
-                    let txHash = hash tx
+                    let txHash = hashed tx
                     modifyTVar' varAdded     succ
                     n <- succ <$> readTVar varMaxN
                     modifyTVar' varFIFO   $ IMap.insert n tx
@@ -184,7 +184,7 @@ newMempool validation = do
                       , show trueTX
                       , show tx
                       ]
-            | let trueTX = Set.fromList (hash <$> toList fifo)
+            | let trueTX = Set.fromList (hashed <$> toList fifo)
             , trueTX /= tx
             ]
           , [ "Duplicate transactions present"


### PR DESCRIPTION
This disallows type of errors when we use hash obtained from value
of wrong type. Such error happened or nearly happened in xenochain