### PR TITLE
Weakens context for class ByteRepr. Removes Ord from context.

### DIFF
--- a/thundermint-crypto/Thundermint/Crypto.hs
+++ b/thundermint-crypto/Thundermint/Crypto.hs
@@ -177,7 +177,7 @@ signatureSize :: forall alg proxy i. (Crypto alg, Num i) => proxy alg -> i
 signatureSize _ = fromIntegral $ natVal (Proxy :: Proxy (SignatureSize alg))
 
 -- | Value could be represented as bytestring.
-class (Ord a) => ByteRepr a where
+class ByteRepr a where
   decodeFromBS :: BS.ByteString -> Maybe a
   encodeToBS   :: a -> BS.ByteString
 


### PR DESCRIPTION
Убран класс Ord из контекста для класса ByteRepr. Если он там есть, то не получается для некоторых фронтовых типов определить ByteRepr