### PR TITLE
Replace list of votes in Commit by NonEmpty

### DIFF
--- a/thundermint-types/Thundermint/Types/Blockchain.hs
+++ b/thundermint-types/Thundermint/Types/Blockchain.hs
@@ -55,6 +55,7 @@ import           Data.Bits                ((.&.))
 import           Data.Coerce
 import           Data.Int
 import           Data.List                (sortBy)
+import qualified Data.List.NonEmpty       as NE
 import           Data.Monoid              ((<>))
 import           Data.Ord                 (comparing)
 import           Data.Time.Clock          (UTCTime)
@@ -252,7 +253,7 @@ instance CryptoHash alg => JSON.ToJSON   (ByzantineEvidence alg a)
 data Commit alg a = Commit
   { commitBlockID    :: !(BlockID alg a)
     -- ^ Block for which commit is done
-  , commitPrecommits :: !([Signed 'Unverified alg (Vote 'PreCommit alg a)])
+  , commitPrecommits :: !(NE.NonEmpty (Signed 'Unverified alg (Vote 'PreCommit alg a)))
     -- ^ List of precommits which justify commit
   }
   deriving (Show, Eq, Generic)
@@ -278,7 +279,7 @@ commitTime vset t0 Commit{..} = do
            )
   -- Here we discard invalid votes and calculate median time
   let times    = sortBy (comparing snd)
-               $ [ (w,voteTime) | (w,Vote{..}) <- votes
+               $ [ (w,voteTime) | (w,Vote{..}) <- NE.toList votes
                                 , voteTime > t0
                                 , voteBlockID == Just commitBlockID
                                 ]

--- a/thundermint/Thundermint/P2P.hs
+++ b/thundermint/Thundermint/P2P.hs
@@ -36,13 +36,14 @@ import           Data.Monoid       ((<>))
 import           Data.Maybe        (mapMaybe)
 import           Data.Foldable
 import           Data.Function
-import qualified Data.Map        as Map
-import           Data.Map          (Map)
-import qualified Data.Set        as Set
-import           Data.Set          (Set)
-import qualified Data.Aeson      as JSON
-import qualified Data.Aeson.TH   as JSON
-import qualified Data.Text       as T
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map           as Map
+import           Data.Map             (Map)
+import qualified Data.Set           as Set
+import           Data.Set             (Set)
+import qualified Data.Aeson         as JSON
+import qualified Data.Aeson.TH      as JSON
+import qualified Data.Text          as T
 import Katip         (showLS,sl)
 import qualified Katip
 import System.Random (newStdGen, randomIO, randomRIO)
@@ -619,7 +620,7 @@ peerGossipVotes peerObj PeerChans{..} gossipCh = logOnException $ do
         case mcmt of
          Just cmt -> do
            let cmtVotes  = Map.fromList [ (signedAddr v, unverifySignature v)
-                                        | v <- commitPrecommits cmt ]
+                                        | v <- NE.toList (commitPrecommits cmt) ]
                -- FIXME: inefficient
            let toSet = Set.fromList
                      . map (fingerprint . validatorPubKey)

--- a/thundermint/Thundermint/Store/Internal/BlockDB.hs
+++ b/thundermint/Thundermint/Store/Internal/BlockDB.hs
@@ -8,6 +8,7 @@ module Thundermint.Store.Internal.BlockDB where
 
 import Codec.Serialise (Serialise,serialise,deserialiseOrFail)
 import Control.Monad (when)
+import qualified Data.List.NonEmpty   as NE
 import qualified Data.ByteString.Lazy as LBS
 import qualified Database.SQLite.Simple           as SQL
 import           Database.SQLite.Simple             (Only(..))
@@ -191,7 +192,7 @@ storeCommit
   => Commit alg a -> Block alg a -> m ()
 storeCommit cmt blk = do
   let h = headerHeight $ blockHeader blk
-      r = voteRound $ signedValue $ head $ commitPrecommits cmt
+      r = voteRound $ signedValue $ NE.head $ commitPrecommits cmt
   basicExecute "INSERT INTO thm_commits VALUES (?,?)" (h, serialise cmt)
   basicExecute "INSERT INTO thm_blockchain VALUES (?,?,?,?)"
     ( h

--- a/thundermint/test/TM/Arbitrary/Instances.hs
+++ b/thundermint/test/TM/Arbitrary/Instances.hs
@@ -9,7 +9,8 @@ module TM.Arbitrary.Instances where
 
 import Data.ByteString.Arbitrary as Arb
 import Data.Maybe
-import qualified Data.ByteString as BS
+import qualified Data.ByteString    as BS
+import qualified Data.List.NonEmpty as NE
 import Test.QuickCheck.Arbitrary
 import Test.QuickCheck.Arbitrary.Generic
 import Test.QuickCheck.Gen
@@ -63,8 +64,7 @@ instance (Arbitrary a) => Arbitrary (Signed sign alg a) where
 
 instance Arbitrary (Commit alg a) where
   arbitrary = Commit <$> arbitrary
-                     <*> resize 4 arbitrary
-  shrink = genericShrink
+                     <*> ((NE.:|) <$> arbitrary <*> resize 3 arbitrary)
 
 
 instance Arbitrary (BlockID alg a) where

--- a/thundermint/test/TM/Time.hs
+++ b/thundermint/test/TM/Time.hs
@@ -5,6 +5,7 @@ module TM.Time (tests) where
 import Control.Monad
 import Data.Int
 import Data.List
+import qualified Data.List.NonEmpty as NE
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -16,8 +17,7 @@ import Thundermint.Types.Validators
 
 tests :: TestTree
 tests = testGroup "time"
-  [ testCase "median 1" $ checkMedian [] Nothing
-  , testCase "median 2" $ checkMedian [(1,123)] (Just 123)
+  [ testCase "median 2" $ checkMedian [(1,123)] (Just 123)
     -- Even
   , testCase "median even 1" $ checkMedian [(1,10), (1,12)]
                                       (Just 11)
@@ -49,7 +49,7 @@ checkMedian wtimes expectedT = forM_ (permuteCommit commit) $ \cmt ->
       ]
     commit = Commit
       { commitBlockID    = bid
-      , commitPrecommits =
+      , commitPrecommits = NE.fromList
           [ signValue pk Vote { voteHeight  = Height 1
                               , voteRound   = Round 0
                               , voteBlockID = Just bid
@@ -64,7 +64,7 @@ permuteCommit Commit{..} =
   [ Commit { commitPrecommits = pc
            , ..
            }
-  | pc <- permutations commitPrecommits
+  | pc <- NE.fromList <$> permutations (NE.toList commitPrecommits)
   ]
 
 bid :: BlockID Ed25519_SHA512 ()


### PR DESCRIPTION
Commit indeed can't have 0 votes.

This is followup for bug in xenochain's mock where we created invalid
Commit value