### PR TITLE
Part of rework of callcack system of thundermint

### DIFF
--- a/thundermint/Thundermint/Mock/KeyVal.hs
+++ b/thundermint/Thundermint/Mock/KeyVal.hs
@@ -107,12 +107,13 @@ interpretSpec maxH prefix NetSpec{..} = do
                              let Just k = find (`Map.notMember` st) ["K_" ++ show (n :: Int) | n <- [1 ..]]
                              return ([(k, addr)], [])
                        --
-                       , appCommitCallback = \case
+                       , appCommitQuery    = SimpleQuery $ \_ -> return []
+                       }
+                     appCall = mempty
+                       { appCommitCallback = \case
                            b | Just hM <- maxH
                              , headerHeight (blockHeader b) > Height hM -> throwM Abort
                              | otherwise                                -> return ()
-                       , appCommitQuery    = SimpleQuery $ \_ -> return []
-                       , appCanCreateBlock = \_ _ -> return True
                        }
                  let cfg = defCfg :: Configuration Example
                  appCh <- newAppChans (cfgConsensus cfg)
@@ -126,7 +127,7 @@ interpretSpec maxH prefix NetSpec{..} = do
                          appCh
                          nullMempoolAny
                    , setNamespace "consensus"
-                     $ runApplication (cfgConsensus cfg) nspecPrivKey appState appCh
+                     $ runApplication (cfgConsensus cfg) nspecPrivKey appState appCall appCh
                    ]
              )
   where


### PR DESCRIPTION

1. Type of callback is changed to `Query alg a [Δ] | QueryT alg a m [Δ]`. After introduction of QueryT we don't need crazy hacks to interleave DB access and other effects

2. AppState is reneamed to AppLogic. It doesn't have any explicit state so name made no sense

3. AppLogic is subsequently split into AppLogic and AppCallaback in order to be able to exploit monoidal structure of appCallback and appCanCreate block