### PR TITLE
thundermint: fix thundermint-bench's build-depends

### DIFF
--- a/thundermint/thundermint.cabal
+++ b/thundermint/thundermint.cabal
@@ -217,6 +217,8 @@ Benchmark thundermint-bench
   Main-is:             main.hs
   Build-Depends:       base  >=4.9 && <5
                      , thundermint
+                     , thundermint-crypto
+                     , thundermint-types
                      , bytestring >=0.10
                      , criterion
                      , cryptonite


### PR DESCRIPTION
Fixes `stack build --bench` and `cabal *bench`