### PR TITLE
Jailbreak bytestring-arbitrary in cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,7 @@ packages:
          thundermint
          thundermint-crypto
          thundermint-types
+
+-- Jailbreak bytestring-arbitrary
+--   https://github.com/tsuraan/bytestring-arbitrary/issues/10
+allow-newer: bytestring-arbitrary:base

--- a/nix/overrides.nix
+++ b/nix/overrides.nix
@@ -19,6 +19,7 @@
   # Compiler specific overrides
   ghc863 = {
     bloodhound           = { check = false; jailbreak = true;};
+    # https://github.com/tsuraan/bytestring-arbitrary/issues/10
     bytestring-arbitrary = { jailbreak = true; };
   };
   ghcjs = {


### PR DESCRIPTION
cabal new-build outside of nix-shell works (at least it's able to resolve dependencies). Change should not have ant effect on nix build