### PR TITLE
Add implementation of special case for PBKDF2

### DIFF
--- a/thundermint-crypto/Thundermint/Crypto/PBKDF2Simple.hs
+++ b/thundermint-crypto/Thundermint/Crypto/PBKDF2Simple.hs
@@ -1,0 +1,23 @@
+-- |
+-- Very simple implementation of one special case of PBKDF2 as use by
+-- xenochain.
+module Thundermint.Crypto.PBKDF2Simple (
+    sha512PBKDF2
+  ) where
+
+import Data.ByteString (ByteString)
+import Crypto.Pbkdf2
+import Data.Digest.Pure.SHA (bytestringDigest, hmacSha512)
+
+import qualified Data.ByteString.Lazy as LB
+
+sha512PBKDF2
+  :: ByteString                 -- ^ Password (secret)
+  -> ByteString                 -- ^ Salt (not necessary secret)
+  -> Int                        -- ^ Number of iteration
+  -> Int                        -- ^ Desired size of output
+  -> ByteString
+sha512PBKDF2 password salt iter size =
+  LB.toStrict $ LB.take (fromIntegral size) $ pbkdf2 sha512 password salt (fromIntegral iter)
+  where
+    sha512 key msg = LB.toStrict $ bytestringDigest $ hmacSha512 (LB.fromStrict key) (LB.fromStrict msg)

--- a/thundermint-crypto/thundermint-crypto.cabal
+++ b/thundermint-crypto/thundermint-crypto.cabal
@@ -34,6 +34,8 @@ Library
                      , deepseq           >=1.4
                      , serialise         >=0.2
                      , text              >=1
+                     , SHA               >=1.6 && <2
+                     , Lazy-Pbkdf2       >=3.1
   if impl(ghcjs)
     hs-source-dirs: ghcjs .
     Build-depends:     ghcjs-prim
@@ -62,6 +64,7 @@ Library
                   Thundermint.Crypto.SHA
                   Thundermint.Crypto.Salsa20Poly1305
                   Thundermint.Crypto.KDFNaCl
+                  Thundermint.Crypto.PBKDF2Simple
 
 Test-suite thundermint-crypto-tests
   if impl(ghcjs)


### PR DESCRIPTION
In fact it's copied verbatim from xenochain because it's needed
NOW.

Main problems are PBKDF is a bit tricky to parametrize. In this library
we usually select algorithms using types and there's no obvious type class
for that. HMACs are commonly used for that purpose so we can say "use
HMACS" but we don't have them either.

In any case this function will work as stopgap measure