### PR TITLE
Pass validator set to callbacks

### DIFF
--- a/thundermint/Thundermint/Blockchain/Internal/Engine/Types.hs
+++ b/thundermint/Thundermint/Blockchain/Internal/Engine/Types.hs
@@ -154,11 +154,11 @@ instance DefaultConfig app => FromJSON (Configuration app) where
 -- | Callback which is called right after block is commited to
 --   database.
 data CommitCallback m alg a
-  = SimpleQuery !(Block alg a -> Query 'RW alg a [ValidatorChange alg])
+  = SimpleQuery !(ValidatorSet alg -> Block alg a -> Query 'RW alg a [ValidatorChange alg])
   -- ^ Query for updating user's state and to find out new set of
   --   validators. It's evaluated in the same transaction as block
   --   commit and thus atomic.
-  | MixedQuery  !(Block alg a -> QueryT 'RW alg a m [ValidatorChange alg])
+  | MixedQuery  !(ValidatorSet alg -> Block alg a -> QueryT 'RW alg a m [ValidatorChange alg])
   -- ^ Query which allow to mixed database updates with other
   --   actions. If @Query@ succeeds returned action is executed immediately
 
@@ -172,10 +172,11 @@ data AppLogic m alg a = AppLogic
                         -> Time
                         -> Maybe (Commit alg a)
                         -> [ByzantineEvidence alg a]
+                        -> ValidatorSet alg
                         -> m (a, [ValidatorChange alg])
     -- ^ Generate fresh block for proposal. It's called each time we
     --   need to create new block for proposal
-  , appValidationFun    :: Block alg a -> m (Maybe [ValidatorChange alg])
+  , appValidationFun    :: ValidatorSet alg -> Block alg a -> m (Maybe [ValidatorChange alg])
     -- ^ Function for validation of proposed block data. It returns
     --   change of validators for given block if it's valid and
     --   @Nothing@ if it's not.
@@ -205,13 +206,13 @@ hoistCommitCallback
   :: (Monad m)
   => (forall x. m x -> n x) -> CommitCallback m alg a -> CommitCallback n alg a
 hoistCommitCallback _   (SimpleQuery f) = SimpleQuery f
-hoistCommitCallback fun (MixedQuery  f) = MixedQuery $ fmap (hoist fun) f
+hoistCommitCallback fun (MixedQuery  f) = MixedQuery $ (fmap . fmap) (hoist fun) f
 
 
 hoistAppLogic :: (Monad m) => (forall x. m x -> n x) -> AppLogic m alg a -> AppLogic n alg a
 hoistAppLogic fun AppLogic{..} = AppLogic
-  { appBlockGenerator   = \h t c e -> fun $ appBlockGenerator h t c e
-  , appValidationFun    = fun . appValidationFun
+  { appBlockGenerator   = \h t c e v -> fun $ appBlockGenerator h t c e v
+  , appValidationFun    = \v b -> fun $ appValidationFun v b
   , appCommitQuery      = hoistCommitCallback   fun appCommitQuery
   }
 

--- a/thundermint/Thundermint/Mock/KeyVal.hs
+++ b/thundermint/Thundermint/Mock/KeyVal.hs
@@ -97,12 +97,12 @@ interpretSpec maxH prefix NetSpec{..} = do
                  bchState <- newBChState transitions
                  _        <- stateAtH bchState (succ hChain)
                  let appState = AppLogic
-                       { appValidationFun  = \b -> do
+                       { appValidationFun  = \_ b -> do
                            let h = headerHeight $ blockHeader b
                            st <- stateAtH bchState h
                            return $ [] <$ processBlock transitions CheckSignature b st
                        --
-                       , appBlockGenerator = \h _ _ _ -> case nspecByzantine of
+                       , appBlockGenerator = \h _ _ _ _ -> case nspecByzantine of
                            Just "InvalidBlock" -> do
                              return ([("XXX", NetAddrV6 (1,2,3,4) 4433)], [])
                            _ -> do
@@ -110,7 +110,7 @@ interpretSpec maxH prefix NetSpec{..} = do
                              let Just k = find (`Map.notMember` st) ["K_" ++ show (n :: Int) | n <- [1 ..]]
                              return ([(k, addr)], [])
                        --
-                       , appCommitQuery    = SimpleQuery $ \_ -> return []
+                       , appCommitQuery    = SimpleQuery $ \_ _ -> return []
                        }
                      appCall = maybe mempty (callbackAbortAtH . Height) maxH
                  let cfg = defCfg :: Configuration Example

--- a/thundermint/test/TM/Validators.hs
+++ b/thundermint/test/TM/Validators.hs
@@ -182,21 +182,21 @@ testAddRemValidators = do
             let logic = NodeLogic {
                   nodeMempool = nodeMempool generatedLogic
                 , nodeCommitQuery = case nodeCommitQuery generatedLogic of
-                      SimpleQuery cb -> SimpleQuery $ \block ->
+                      SimpleQuery cb -> SimpleQuery $ \vset block ->
                           let addChanges = case (elem Add $ blockData block, elem Del $ blockData block) of
                                 (True, False) -> [ChangeValidator dynamicValidatorPubKey 10]
                                 (False, True) -> [RemoveValidator dynamicValidatorPubKey]
                                 _ -> []
-                          in fmap (addChanges ++) $ cb block
+                          in (addChanges ++) <$> cb vset block
                       MixedQuery _ -> error "mixed query in test!"
-                , nodeBlockGenerator = \height time maybeCommit byzantineEvidence -> do
-                  (block', changes) <- nodeBlockGenerator generatedLogic height time maybeCommit byzantineEvidence
+                , nodeBlockGenerator = \height time maybeCommit byzantineEvidence vSet -> do
+                  (block', changes) <- nodeBlockGenerator generatedLogic height time maybeCommit byzantineEvidence vSet
                   let block = OriginMark nodeIndex : block'
                   case height of
                     Height 20 -> return (Add : block, ChangeValidator dynamicValidatorPubKey 10 : changes)
                     Height 40 -> return (Del : block, RemoveValidator dynamicValidatorPubKey : changes)
                     _         -> return (block, changes)
-                , nodeBlockValidation = \block -> do
+                , nodeBlockValidation = \valSet block -> do
                     let header = blockHeader block
                         txs = blockData block
                         h = headerHeight header
@@ -206,7 +206,7 @@ testAddRemValidators = do
                     when (h > Height 60) $ throwM Abort
                     when (nodeIndex < 4) $ liftIO $ modifyMVar_ summary $
                       return . (|| blockContainsDynamic)
-                    changes <- nodeBlockValidation generatedLogic block
+                    changes <- nodeBlockValidation generatedLogic valSet block
                     let addChanges = case (elem Add $ blockData block, elem Del $ blockData block) of
                           (True, False) -> [ChangeValidator dynamicValidatorPubKey 10]
                           (False, True) -> [RemoveValidator dynamicValidatorPubKey]


### PR DESCRIPTION
Consensus engine knows ground truth about current validator set for a block so it makes sense to pass it to the user. Turns out it's useful for any nontrivial logic involving change of validator state

We should return new set of validators instead of delta but it requires significant changes. We must execute genesis block before we start consensus process and we don;t have infrastructure for that
