### PR TITLE
Fix unreproducibility in bls-signatures

### DIFF
--- a/nix/derivations/nix/0001-Remove-GMP-linking.patch
+++ b/nix/derivations/nix/0001-Remove-GMP-linking.patch
@@ -1,3 +1,12 @@
+From 6bcfc2c7c08b06adca9c0a8a6352a2cdb9e60836 Mon Sep 17 00:00:00 2001
+From: Alexey Khudyakov <alexey.skladnoy@gmail.com>
+Date: Wed, 27 Nov 2019 12:05:16 +0300
+Subject: [PATCH 1/2] Remove GMP linking
+
+---
+ src/CMakeLists.txt | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
 index 01d499f..2f035de 100644
 --- a/src/CMakeLists.txt
@@ -15,3 +24,6 @@ index 01d499f..2f035de 100644
  if (SODIUM_FOUND)
    list(APPEND LIBRARIES_TO_COMBINE COMMAND mkdir ${OPREFIX}sodium || true && cd ${OPREFIX}sodium &&  ${CMAKE_AR} -x ${SODIUM_NAME})
  endif()
+-- 
+2.23.0
+

--- a/nix/derivations/nix/0002-Patch-out-building-of-ython-bindings.patch
+++ b/nix/derivations/nix/0002-Patch-out-building-of-ython-bindings.patch
@@ -1,0 +1,27 @@
+From cbecd86317c9f5b65f60f215523c38713d4c1c7c Mon Sep 17 00:00:00 2001
+From: Alexey Khudyakov <alexey.skladnoy@gmail.com>
+Date: Wed, 27 Nov 2019 12:08:10 +0300
+Subject: [PATCH 2/2] Patch out building of ython bindings
+
+It's funny: pybind11 is added as a submodule without pinning(!) thus nix fetch
+latest masyter and breaks reproducibility
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e1c2084..bbf9963 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -82,6 +82,6 @@ if (EMSCRIPTEN)
+   add_subdirectory(js-bindings)
+ else()
+   # emscripten can't build python bindings, it produces only javascript
+-  add_subdirectory(contrib/pybind11)
+-  add_subdirectory(python-bindings)
++  # add_subdirectory(contrib/pybind11)
++  # add_subdirectory(python-bindings)
+ endif()
+-- 
+2.23.0
+

--- a/nix/derivations/nix/bls.nix
+++ b/nix/derivations/nix/bls.nix
@@ -5,18 +5,17 @@ stdenv.mkDerivation rec {
   buildInputs       = [ gmp ];
   nativeBuildInputs = [ cmake python ];
 
-  # We need to clone submodules as well.
-  #
-  # deepClone is workaround for that
   src = fetchgit {
     url       = "https://github.com/Chia-Network/bls-signatures";
-    deepClone = true;
     rev       = "93e4f4118b326e7f5e2bec1445cc68aac0728026";
-    sha256    = "1ns76irr34myr0vzmbw5yw22m7vpg91b1la8s5qg6asngvrdvzik";
+    sha256    = "13x9rvsfdpjhwrgbzr08c27633dz5gvlgh4974x2r0chrz6q94xd";
   };
   # Patch out linking for GMP. We still build with GMP but don't link
   # it since it causes problems when linking haskell programs
-  patches = [ ./remove-gmp-from-linking.patch ];
+  patches = [
+    ./0001-Remove-GMP-linking.patch
+    ./0002-Patch-out-building-of-ython-bindings.patch
+    ];
   # chiabls/bls.hpp uses:
   #
   # > #include "relic_conf.h"


### PR DESCRIPTION
Submodule for python bindings wasn't pinned so when we fetched sourse we get
unreproducible results: latest pybind11 master

Solution is simple - pactch out python bindings from build process