### PR TITLE
Fix possibility of leaking threads from runConcurrently

### DIFF
--- a/hschain/HSChain/Control.hs
+++ b/hschain/HSChain/Control.hs
@@ -170,6 +170,7 @@ runConcurrently
   => [m ()]              -- ^ Functions to run
   -> m ()
 runConcurrently []      = return ()
+runConcurrently [act]   = act
 runConcurrently actions = do
   -- We communicate return status of thread via channel since we don't
   -- know a priory which will terminated first


### PR DESCRIPTION
killThread block in bracket cleanup and tehrefore could be interrupted. Instead
create thread which only calls killThread. This is safe since calls to forkIO
couldn't be interrupted. It should kill threads markginally faster and cost of
creating multiple threads

Fixes #536