### PR TITLE
Improve error messages for exceptions when rewinding

### DIFF
--- a/hschain/HSChain/Blockchain/Internal/Engine.hs
+++ b/hschain/HSChain/Blockchain/Internal/Engine.hs
@@ -97,15 +97,24 @@ rewindBlockchainState AppStore{..} BChLogic{..} = do
                                 , blockchainState = st
                                 }
       -- Check validator set consistency
-      unless (merkleHashed blockchainState == blockStateHash blk)
-        $ throwM $ InconsistenceWhenRewinding h
-          "Hash of calculated state doesn't match hash in block"
-      unless (hashed valSet == blockValidators blk)
-        $ throwM $ InconsistenceWhenRewinding h
-          "Validator set doesn't match validator set stored in block"
-      unless (merkleHashed validatorSet    == blockNewValidators blk)
-        $ throwM $ InconsistenceWhenRewinding h
-          "New validator set doesn't match validator set stored in block"
+      do let Hashed expectedValue = blockStateHash blk
+             Hashed actualValue   = merkleHashed blockchainState
+         unless (expectedValue == actualValue)
+           $ throwM $ InconsistenceWhenRewinding h
+                      "Hash of calculated state doesn't match hash in block"
+                      Mismatch{..}
+      do let Hashed expectedValue = blockValidators blk
+             Hashed actualValue   = hashed valSet
+         unless (expectedValue == actualValue)
+           $ throwM $ InconsistenceWhenRewinding h
+                      "Validator set doesn't match validator set stored in block"
+                      Mismatch{..}
+      do let Hashed expectedValue = blockNewValidators blk
+             Hashed actualValue   = merkleHashed validatorSet
+         unless (expectedValue == actualValue)
+           $ throwM $ InconsistenceWhenRewinding h
+                      "New validator set doesn't match validator set stored in block"
+                      Mismatch{..}
       -- Write validator set at H=1 to database if needed
       when (h == Height 0) $ do
         queryRO (hasValidatorSet (Height 1)) >>= \case


### PR DESCRIPTION
Changes:
 - Custom displayException is added to InternalError
 - InconsistenceWhenRewinding stores offending hashes

```
InconsistenceWhenRewinding :: InternalError
  H of block that caused problem:
    Height 0
  Problem:
    Hash of calculated state doesn't match hash in block
  Expected hash (one that stored in block):
    Hash "swHmGH77tnTt3pc3sgCcgjakiyH"
  Hash of computed value:
    Hash "3GTLSwo2jMqQ8rSAkqoBVZ1poXg"
```