### PR TITLE
Add directional channels & updates to PoW types

### DIFF
--- a/hschain-PoW/HSChain/PoW/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/Consensus.hs
@@ -25,7 +25,6 @@ module HSChain.PoW.Consensus
   , candidateHeads
   , badBlocks
   , requiredBlocks
-  , blockDB
     --
   , consensusGenesis
   , Head(..)
@@ -198,22 +197,19 @@ data Consensus m b = Consensus
     --   here. However we only add its descendants when
   , _requiredBlocks :: Set (BlockID b)
     -- ^ Set of blocks that we need to fetch from other ndoes.
-  , _blockDB        :: BlockDB m b
   }
 
 consensusGenesis
   :: (Monad m, BlockData b)
   => Block b
   -> StateView m b
-  -> BlockDB   m b
   -> Consensus m b
-consensusGenesis genesis sview db = Consensus
+consensusGenesis genesis sview = Consensus
   { _blockIndex     = idx
   , _bestHead       = (bh, sview)
   , _candidateHeads = []
   , _badBlocks      = Set.empty
   , _requiredBlocks = Set.empty
-  , _blockDB        = db
   }
   where
     bid = blockID genesis
@@ -365,9 +361,10 @@ growNewHead bh = do
 -- | Add new block. We only accept block if we already have valid header. Note
 processBlock
   :: (BlockData b, Monad m)
-  => Block b
+  => BlockDB m b
+  -> Block b
   -> ExceptT BlockError (StateT (Consensus m b) m) ()
-processBlock block = do
+processBlock db block = do
   index <- use blockIndex
   _bh   <- maybe (throwError ErrB'UnknownBlock) return
          $ bid `lookupIdx` index
@@ -379,8 +376,7 @@ processBlock block = do
   case validateBlock block of
     False -> do invalidateBlock bid
                 throwError ErrB'InvalidBlock
-    True  -> do db <- use blockDB
-                lift $ lift $ storeBlock db block
+    True  -> do lift $ lift $ storeBlock db block
   -- Now we want to find candidate heads that are better than current
   -- head and reachable at the same time.
   --
@@ -392,7 +388,7 @@ processBlock block = do
   --             |    |    |- next best head
   --             |    |- block we're processing
   --             |- current best head
-  bestCandidate
+  bestCandidate db
   where
     bid          = blockID block
 
@@ -421,9 +417,9 @@ invalidateBlock bid = do
 -- | Find best reachable candidate block.
 bestCandidate
   :: (BlockData b, Monad m)
-  => ExceptT BlockError (StateT (Consensus m b) m) ()
-bestCandidate = do
-  db       <- use blockDB
+  => BlockDB m b
+  -> ExceptT BlockError (StateT (Consensus m b) m) ()
+bestCandidate db = do
   bestWork <- use $ bestHead . _1 . to bhWork
   missing  <- use requiredBlocks
   heads    <- use $ candidateHeads . to (  mapMaybe (findBest missing)
@@ -445,9 +441,8 @@ bestCandidate = do
       state' <- lift $ lift
               $ runExceptT
               $ traverseBlockIndexM rollback update best h st
-      -- traceShow ("BEST HEAD:",bhBID h) $ return ()
       case state' of
-        Left  bid -> invalidateBlock bid >> bestCandidate
+        Left  bid -> invalidateBlock bid >> bestCandidate db
         Right s   -> bestHead .= (h,s)   >> cleanCandidates
   where
     findBest missing Head{..} =

--- a/hschain-PoW/HSChain/PoW/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/Consensus.hs
@@ -11,6 +11,7 @@ module HSChain.PoW.Consensus
   ( -- * Block index
     BlockIndex(..)
   , BH(..)
+  , asHeader
   , insertIdx
   , lookupIdx
   , blockIndexFromGenesis
@@ -135,6 +136,13 @@ data BH b = BH
   , bhWork     :: !(Work b)       --
   , bhPrevious :: !(Maybe (BH b)) --
   , bhData     :: !(b Hashed)     --
+  }
+
+asHeader :: BH b -> Header b
+asHeader bh = GBlock
+  { blockHeight = bhHeight bh
+  , prevBlock   = bhBID <$> bhPrevious bh
+  , blockData   = bhData bh
   }
 
 deriving instance (Show (Work b), Show (BlockID b), Show (b Hashed)) => Show (BH b)

--- a/hschain-control/HSChain/Control/Channels.hs
+++ b/hschain-control/HSChain/Control/Channels.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+-- |
+module HSChain.Control.Channels where
+
+import Control.Applicative
+import Control.Concurrent.STM
+import Control.Monad.IO.Class
+import Data.Functor.Contravariant
+
+import HSChain.Control.Util
+
+
+-- | Sink for channels
+newtype Sink a = Sink { sink :: a -> STM () }
+
+sinkIO :: MonadIO m => Sink a -> a -> m ()
+sinkIO s = atomicallyIO . sink s
+
+instance Contravariant Sink where
+  contramap f (Sink s) = Sink $ s . f
+
+instance Semigroup (Sink a) where
+  Sink f <> Sink g = Sink $ \a -> f a >> g a
+
+instance Monoid (Sink a) where
+  mempty = Sink $ \_ -> return ()
+
+
+-- | Source of data in concurrent programs
+newtype Src a = Src { await :: STM a }
+  deriving newtype Functor
+
+awaitIO :: MonadIO m => Src a -> m a
+awaitIO = atomicallyIO . await
+
+instance Semigroup (Src a) where
+  Src a <> Src b = Src $ a <|> b
+
+instance Monoid (Src a) where
+  mempty = Src empty
+
+
+queuePair :: MonadIO m => m (Sink a, Src a)
+queuePair = do
+  q <- liftIO newTQueueIO
+  return ( Sink $ writeTQueue q
+         , Src  $ readTQueue  q
+         )

--- a/hschain-control/HSChain/Control/Channels.hs
+++ b/hschain-control/HSChain/Control/Channels.hs
@@ -47,3 +47,11 @@ queuePair = do
   return ( Sink $ writeTQueue q
          , Src  $ readTQueue  q
          )
+
+broadcastPair :: MonadIO m => m (Sink a, STM (Src a))
+broadcastPair = do
+  ch <- liftIO newBroadcastTChanIO
+  return ( Sink $ writeTChan ch
+         , do ch' <- dupTChan ch
+              return $ Src $ readTChan ch'
+         )

--- a/hschain-control/hschain-control.cabal
+++ b/hschain-control/hschain-control.cabal
@@ -24,6 +24,7 @@ Library
                      , transformers
                      , containers
   Exposed-modules:
+                  HSChain.Control.Channels
                   HSChain.Control.Class
                   HSChain.Control.Mutex
                   HSChain.Control.Shepherd


### PR DESCRIPTION
1. Add directional composable channels `Src`/`Sink`

2. Move BlockDb from Consensus (it never) changes

3. Add `asHeader` function