### PR TITLE
Store test executables in nix artifacts

### DIFF
--- a/hschain-crypto/hschain-crypto.cabal
+++ b/hschain-crypto/hschain-crypto.cabal
@@ -70,7 +70,7 @@ Library
                   HSChain.Crypto.KDFNaCl
                   HSChain.Crypto.PBKDF2Simple
 
-Test-suite thundermint-crypto-tests
+Test-suite hschain-crypto-tests
   if impl(ghcjs)
     js-sources: js/nacl-fast.js
   --

--- a/hschain-examples/test/TM/Integration.hs
+++ b/hschain-examples/test/TM/Integration.hs
@@ -28,8 +28,8 @@ import           TM.Util.Network (withTimeOut)
 tests :: TestTree
 tests = testGroup "generate blockchain and check on consistency"
   [ testGroup "blockhains"
-    [ localOption (1 :: NumThreads) $ testCase "key-val db" $ withTimeOut 60e6 runKeyVal
-    , localOption (1 :: NumThreads) $ testCase "Mock coin"  $ withTimeOut 60e6 runCoin
+    [ localOption (1 :: NumThreads) $ testCase "key-val db" $ withTimeOut 20e6 runKeyVal
+    , localOption (1 :: NumThreads) $ testCase "Mock coin"  $ withTimeOut 20e6 runCoin
     ]
   ]
 

--- a/hschain-examples/test/TM/Integration.hs
+++ b/hschain-examples/test/TM/Integration.hs
@@ -149,9 +149,9 @@ runCoin = evalContT $ do
         let c = defCfg
         in  c { cfgConsensus = ConsensusCfg
                 { timeoutNewHeight  = 10
-                , timeoutProposal   = (50,50)
-                , timeoutPrevote    = (50,50)
-                , timeoutPrecommit  = (50,50)
+                , timeoutProposal   = (50,250)
+                , timeoutPrevote    = (50,250)
+                , timeoutPrecommit  = (50,250)
                 , timeoutEmptyBlock = 100
                 , incomingQueueSize = 10
                 }

--- a/hschain-examples/test/TM/Validators.hs
+++ b/hschain-examples/test/TM/Validators.hs
@@ -159,9 +159,9 @@ testValidatorChange = withTimeOut 20e6 $ do
         let c = defCfg
         in  c { cfgConsensus = ConsensusCfg
                 { timeoutNewHeight  = 10
-                , timeoutProposal   = (100,100)
-                , timeoutPrevote    = (100,100)
-                , timeoutPrecommit  = (100,100)
+                , timeoutProposal   = (100,500)
+                , timeoutPrevote    = (100,500)
+                , timeoutPrecommit  = (100,500)
                 , timeoutEmptyBlock = 100
                 , incomingQueueSize = 10
                 }

--- a/nix/config.nix
+++ b/nix/config.nix
@@ -1,4 +1,5 @@
 # Default configuration
 {
-  ghc = "ghc883";
+  ghc       = "ghc883";
+  useSodium = false;
 }

--- a/nix/containers.nix
+++ b/nix/containers.nix
@@ -9,7 +9,8 @@ in
 let
   release = import ./release.nix {
     inherit isProd isProfile;
-    ghcToUse = ghc;
+    useSodium = cfg.useSodium;
+    ghcToUse  = ghc;
   };
   pkgs = release.pkgs;
   lib = pkgs.haskell.lib;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,7 +4,7 @@ in
 , isProd     ? false
 , isCoreLint ? false
 , isBench    ? false
-, useSodium  ? true
+, useSodium  ? cfg.useSodium
 , ghc        ? cfg.ghc
 }:
 let

--- a/nix/derivations/ghc84/tasty.nix
+++ b/nix/derivations/ghc84/tasty.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, fetchgit
+, ansi-terminal, async, base, clock, containers, mtl
+, optparse-applicative, stdenv, stm, tagged, unbounded-delays, unix
+, wcwidth
+}:
+mkDerivation {
+  pname = "tasty";
+  version = "1.2.3";
+  src = fetchgit {
+    url       = "https://github.com/Shimuuar/tasty";
+    rev       = "eb0bbed5996030bb1acfe474dd04056604ce8960";
+    sha256    = "sha256:1xvjw05952w3z2mms12k27xd0y5fvqp9aar8kdl90la16ffjc2y9";
+  };
+
+  postUnpack = "sourceRoot+=/core; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [
+    ansi-terminal async base clock containers mtl optparse-applicative
+    stm tagged unbounded-delays unix wcwidth
+  ];
+  homepage = "https://github.com/feuerbach/tasty";
+  description = "Modern and extensible testing framework";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/derivations/ghc86/tasty.nix
+++ b/nix/derivations/ghc86/tasty.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, fetchgit
+, ansi-terminal, async, base, clock, containers, mtl
+, optparse-applicative, stdenv, stm, tagged, unbounded-delays, unix
+, wcwidth
+}:
+mkDerivation {
+  pname = "tasty";
+  version = "1.2.3";
+  src = fetchgit {
+    url       = "https://github.com/Shimuuar/tasty";
+    rev       = "eb0bbed5996030bb1acfe474dd04056604ce8960";
+    sha256    = "sha256:1xvjw05952w3z2mms12k27xd0y5fvqp9aar8kdl90la16ffjc2y9";
+  };
+
+  postUnpack = "sourceRoot+=/core; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [
+    ansi-terminal async base clock containers mtl optparse-applicative
+    stm tagged unbounded-delays unix wcwidth
+  ];
+  homepage = "https://github.com/feuerbach/tasty";
+  description = "Modern and extensible testing framework";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/derivations/ghc88/tasty.nix
+++ b/nix/derivations/ghc88/tasty.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, fetchgit
+, ansi-terminal, async, base, clock, containers, mtl
+, optparse-applicative, stdenv, stm, tagged, unbounded-delays, unix
+, wcwidth
+}:
+mkDerivation {
+  pname = "tasty";
+  version = "1.2.3";
+  src = fetchgit {
+    url       = "https://github.com/Shimuuar/tasty";
+    rev       = "eb0bbed5996030bb1acfe474dd04056604ce8960";
+    sha256    = "sha256:1xvjw05952w3z2mms12k27xd0y5fvqp9aar8kdl90la16ffjc2y9";
+  };
+
+  postUnpack = "sourceRoot+=/core; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [
+    ansi-terminal async base clock containers mtl optparse-applicative
+    stm tagged unbounded-delays unix wcwidth
+  ];
+  homepage = "https://github.com/feuerbach/tasty";
+  description = "Modern and extensible testing framework";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/overrides.nix
+++ b/nix/overrides.nix
@@ -4,10 +4,12 @@
   derivations = {
     haskell = ./derivations/haskell;
     ghc844  = ./derivations/ghc84;
+    ghc865  = ./derivations/ghc86;
+    ghc883  = ./derivations/ghc88;
   };
   # Common overrides for librarise
   haskell = {
-    Diff                = { check = false; };
+    Diff           = { check = false; };
     #
     hschain-crypto = { haddock = false; };
     hschain-types  = { haddock = false; };

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -2,7 +2,7 @@
 , isProd     ? false
 , isCoreLint ? false
 , isBench    ? false
-, useSodium  ? true
+, useSodium
 , ghcToUse
 , ...
 }:

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -64,7 +64,9 @@ let
   hook = ''
     mkdir $out/tests
     for tst in $(grep -i test-suite *.cabal | sed -e 's/ $//; s/.* //'); do
-      cp -v $(find -name $tst -type f) $out/tests
+        if [ $(find -name $tst -type f | wc -l) == 1 ]; then
+            cp -v $(find -name $tst -type f ) $out/tests
+        fi
     done
   '';
   lintOverride    = doIf isCoreLint hask.doCoreLint;

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -4,7 +4,7 @@ in
 , isProd     ? false
 , isCoreLint ? false
 , isBench    ? true
-, useSodium  ? true
+, useSodium  ? cfg.useSodium
 , ghc        ? cfg.ghc
 }:
 let


### PR DESCRIPTION
This is part of hunt for the #587. It seems that some builds crash and some don't preserving tests is thus important to be able to reproduce fault

 - There're few unrelated tweaks in tests
 - We use cryptonite by default. Mostly in order to rule out problems with libsodium bindings