### PR TITLE
Finally fix mysterious memory corrpution #587, #594

### DIFF
--- a/hschain-PoW/HSChain/PoW/Exceptions.hs
+++ b/hschain-PoW/HSChain/PoW/Exceptions.hs
@@ -43,6 +43,12 @@ data CorruptedDBError
   deriving stock    (Show)
   deriving anyclass (Exception)
 
+-- | Trying to access closed database
+data DatabaseIsClosed = DatabaseIsClosed
+  deriving stock    (Show)
+  deriving anyclass (Exception)
+
+
 -- | Internal error in algorithm. Could only occure either because of
 --   bug or due to data corruption.
 data InternalError

--- a/hschain/HSChain/Exceptions.hs
+++ b/hschain/HSChain/Exceptions.hs
@@ -28,6 +28,11 @@ data CorruptedDBError
   deriving stock    (Show)
   deriving anyclass (Exception)
 
+-- | Trying to access closed database
+data DatabaseIsClosed = DatabaseIsClosed
+  deriving stock    (Show)
+  deriving anyclass (Exception)
+
 -- | Internal error in algorithm. Could only occure either because of
 --   bug or due to data corruption.
 data InternalError


### PR DESCRIPTION
Core of the problem is banal use-after-free. sqlite's database's handle is
allocated by malloc and if we use handle after close we are modifying memory
owned by malloc, possibly overweriting malloc's data structures and causeing all
sort of mischief. It manifested itself in many ways:

 - SQLite sometimes detected API misuse (#594)
 - Sometimes malloc detected corruption of its structures
 - Sometimes we get plain segfault

Use after free is caused by data race when thread using connection receives
exception and aborts _after_ database is closed. In addition runConcurrently
waits for all child threads when it terminates when one of its child threads
terminates for whatever reason. But if it is aborted by exception it doesn't
and this opens way for races.

Proposed fix is very simple: check whether connection is already closed and
throw exception if so. It doesn't require any changes in the rest of the
code. If thread is killed by DatabaseIsClosed exception it's going to be killed
by ThreadKilled anyway

We really should factor *.Query into separate package. But that's work for
another PR