### PR TITLE
Refactor hschain-merkle

### DIFF
--- a/hschain-PoW/HSChain/Examples/Simple.hs
+++ b/hschain-PoW/HSChain/Examples/Simple.hs
@@ -28,17 +28,17 @@ data KV f = KV
   { kvData :: MerkleNode f SHA256 [(Int,String)]
   }
   deriving stock (Generic)
-deriving stock instance Show1 (f SHA256) => Show (KV f)
-deriving stock instance IsMerkle f => Eq (KV f)
-instance Serialise (KV IdNode)
-instance Serialise (KV Hashed)
+deriving stock instance Show1    f => Show (KV f)
+deriving stock instance IsMerkle f => Eq   (KV f)
+instance Serialise (KV Identity)
+instance Serialise (KV Proxy)
 
 
 instance IsMerkle f => CryptoHashable (KV f) where
   hashStep = genericHashStep "hschain"
 
 instance MerkleMap KV where
-  merkleMap f (KV (MerkleNode a)) = KV (MerkleNode (f a))
+  merkleMap f (KV d) = KV $ mapMerkleNode f d
 
 instance BlockData KV where
   newtype BlockID KV = KV'BID (Hash SHA256)

--- a/hschain-PoW/HSChain/PoW/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/Consensus.hs
@@ -119,7 +119,7 @@ blockIndexFromGenesis genesis
              , bhBID      = bid
              , bhWork     = blockWork genesis
              , bhPrevious = Nothing
-             , bhData     = merkleMap merkleHashed $ blockData genesis
+             , bhData     = merkleMap (const Proxy) $ blockData genesis
              }
 
 lookupIdx :: (Ord (BlockID b)) => BlockID b -> BlockIndex b -> Maybe (BH b)
@@ -136,7 +136,7 @@ data BH b = BH
   , bhBID      :: !(BlockID b)    --
   , bhWork     :: !Work           --
   , bhPrevious :: !(Maybe (BH b)) --
-  , bhData     :: !(b Hashed)     --
+  , bhData     :: !(b Proxy)      --
   }
 
 asHeader :: BH b -> Header b
@@ -146,7 +146,7 @@ asHeader bh = GBlock
   , blockData   = bhData bh
   }
 
-deriving instance (Show (BlockID b), Show (b Hashed)) => Show (BH b)
+deriving instance (Show (BlockID b), Show (b Proxy)) => Show (BH b)
 
 instance BlockData b => Eq (BH b) where
   a == b = bhBID a == bhBID b

--- a/hschain-PoW/HSChain/PoW/Logger.hs
+++ b/hschain-PoW/HSChain/PoW/Logger.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE PolyKinds                  #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TemplateHaskell            #-}
@@ -280,7 +281,7 @@ makeJsonFileScribe nm sev verb = do
 ----------------------------------------------------------------
 
 -- | Wrapper for log data for logging purposes
-data LogBlockInfo (a :: (* -> * -> *) -> *) = LogBlockInfo !Height {-!(Block a)-} !Int
+data LogBlockInfo a = LogBlockInfo !Height {-!(Block a)-} !Int
 
 instance BlockData a => ToObject (LogBlockInfo a) where
   toObject (LogBlockInfo (Height h) ns)

--- a/hschain-PoW/HSChain/PoW/P2P.hs
+++ b/hschain-PoW/HSChain/PoW/P2P.hs
@@ -38,8 +38,8 @@ data PoW m b = PoW
 
 startNode
   :: ( MonadMask m, MonadFork m, MonadLogger m
-     , Serialise (b IdNode)
-     , Serialise (b Hashed)
+     , Serialise (b Identity)
+     , Serialise (b Proxy)
      , Serialise (BlockID b)
      , BlockData b
      )

--- a/hschain-PoW/HSChain/PoW/P2P/Handler/PEX.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Handler/PEX.hs
@@ -40,8 +40,8 @@ import HSChain.Types.Merkle.Types
 
 runPEX
   :: ( MonadMask m, MonadFork m, MonadLogger m
-     , Serialise (b IdNode)
-     , Serialise (b Hashed)
+     , Serialise (b Identity)
+     , Serialise (b Proxy)
      , BlockData b
      )
   => NetCfg
@@ -82,8 +82,8 @@ runPEX cfg netAPI seeds blockReg sinkBOX mkSrcAnn consSt db = do
 
 acceptLoop
   :: ( MonadMask m, MonadFork m, MonadLogger m
-     , Serialise (b IdNode)
-     , Serialise (b Hashed)
+     , Serialise (b Identity)
+     , Serialise (b Proxy)
      , BlockData b
      )
   => NetworkAPI
@@ -118,8 +118,8 @@ acceptLoop NetworkAPI{..} shepherd reg nonceSet mkChans  = do
 
 connectTo
   :: ( MonadMask m, MonadFork m, MonadLogger m
-     , Serialise (b IdNode)
-     , Serialise (b Hashed)
+     , Serialise (b Identity)
+     , Serialise (b Proxy)
      , BlockData b
      )
   => NetworkAPI
@@ -162,8 +162,8 @@ monitorKnownPeers NetCfg{..} reg sinkPeers = forever $ do
 
 monitorConnections
   :: ( MonadMask m, MonadFork m, MonadLogger m
-     , Serialise (b IdNode)
-     , Serialise (b Hashed)
+     , Serialise (b Identity)
+     , Serialise (b Proxy)
      , BlockData b
      )
   => NetCfg

--- a/hschain-PoW/HSChain/PoW/P2P/Handler/Peer.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Handler/Peer.hs
@@ -45,8 +45,8 @@ import HSChain.Types.Merkle.Types
 --   registered peer
 runPeer
   :: ( MonadMask m, MonadLogger m, MonadFork m
-     , Serialise (b IdNode)
-     , Serialise (b Hashed)
+     , Serialise (b Identity)
+     , Serialise (b Proxy)
      , Serialise (BlockID b)
      , BlockData b
      )
@@ -143,8 +143,8 @@ peerRequestAddresses PeerState{..} PeerChans{..} sinkGossip =
 -- Thread for sending messages over network
 peerSend
   :: ( MonadIO m, MonadLogger m, MonadCatch m
-     , Serialise (b IdNode)
-     , Serialise (b Hashed)
+     , Serialise (b Identity)
+     , Serialise (b Proxy)
      , Serialise (BlockID b)
      )
   => P2PConnection
@@ -159,8 +159,8 @@ peerSend conn src
 -- and routes other messages to respective handlers
 peerRecv
   :: ( MonadMask m, MonadIO m, MonadLogger m
-     , Serialise (b IdNode)
-     , Serialise (b Hashed)
+     , Serialise (b Identity)
+     , Serialise (b Proxy)
      , Serialise (BlockID b)
      , BlockData b
      )

--- a/hschain-PoW/HSChain/PoW/P2P/Types.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Types.hs
@@ -44,7 +44,6 @@ import Data.Word
 import qualified Data.Aeson as JSON
 import GHC.Generics               (Generic)
 
-import HSChain.Crypto
 import HSChain.Network.Types
 import HSChain.PoW.Types
 import HSChain.PoW.Consensus
@@ -89,10 +88,10 @@ data GossipMsg b
   | GossipResp !(MsgResponce b)
   | GossipAnn  !(MsgAnn b)
   deriving stock (Generic)
-deriving stock instance (Show (BlockID b), Show (b Hashed), Show (b IdNode)) => Show (GossipMsg b)
+deriving stock instance (Show (BlockID b), Show (b Proxy), Show (b Identity)) => Show (GossipMsg b)
 
-instance ( Serialise (b IdNode)
-         , Serialise (b Hashed)
+instance ( Serialise (b Identity)
+         , Serialise (b Proxy)
          , Serialise (BlockID b)
          ) => Serialise (GossipMsg b)
 
@@ -116,7 +115,7 @@ data MsgRequest b
   deriving stock (Generic)
 deriving stock instance Show (BlockID b) => Show (MsgRequest b)
 
-instance ( Serialise (b Hashed)
+instance ( Serialise (b Proxy)
          , Serialise (BlockID b)
          ) => Serialise (MsgRequest b)
 
@@ -131,10 +130,10 @@ data MsgResponce b
   | RespNack
   -- ^ Responce was denied.
   deriving stock (Generic)
-deriving stock instance (Show (BlockID b), Show (b Hashed), Show (b IdNode)) => Show (MsgResponce b)
+deriving stock instance (Show (BlockID b), Show (b Proxy), Show (b Identity)) => Show (MsgResponce b)
 
-instance ( Serialise (b IdNode)
-         , Serialise (b Hashed)
+instance ( Serialise (b Identity)
+         , Serialise (b Proxy)
          , Serialise (BlockID b)
          ) => Serialise (MsgResponce b)
 
@@ -143,10 +142,10 @@ data MsgAnn b
   = AnnBestHead !(Header b)
   -- ^ Send new best head to peer. Generally sent unannounced.
   deriving stock (Generic)
-deriving stock instance (Show (BlockID b), Show (b Hashed)) => Show (MsgAnn b)
+deriving stock instance (Show (BlockID b), Show (b Proxy)) => Show (MsgAnn b)
 
 
-instance ( Serialise (b Hashed)
+instance ( Serialise (b Proxy)
          , Serialise (BlockID b)
          ) => Serialise (MsgAnn b)
 

--- a/hschain-PoW/HSChain/PoW/Store/Internal/Query.hs
+++ b/hschain-PoW/HSChain/PoW/Store/Internal/Query.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE PolyKinds                  #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TupleSections              #-}
@@ -316,7 +317,7 @@ instance MonadDB     m a => MonadDB     (Proxy x x' y y' m) a
 --   if DB transaction does not succeed. For example changes to
 --   @StateT@ will while @IO@-effects obviously won't. Proceed with
 --   caution.
-newtype QueryT (rw :: Access) (a :: (* -> * -> *) -> *) m x = QueryT { unQueryT :: m x }
+newtype QueryT (rw :: Access) a m x = QueryT { unQueryT :: m x }
   deriving newtype ( Functor, Applicative, MonadIO, MonadThrow, MonadCatch, MonadMask, MonadLogger)
 
 instance MFunctor (QueryT rw a) where

--- a/hschain-PoW/HSChain/PoW/Types.hs
+++ b/hschain-PoW/HSChain/PoW/Types.hs
@@ -99,7 +99,7 @@ deriving stock instance (Eq (BlockID b), Eq (b f)) => Eq (GBlock b f)
 deriving stock instance (Show (BlockID b), Show (b f)) => Show (GBlock b f)
 
 toHeader :: MerkleMap b => Block b -> Header b
-toHeader = merkleMap merkleHashed
+toHeader = merkleMap (const Proxy)
 
 instance ( forall g. IsMerkle g => CryptoHashable (b g)
          , IsMerkle f
@@ -113,8 +113,8 @@ instance MerkleMap b => MerkleMap (GBlock b) where
                                   }
 
 
-type Header b = GBlock b Hashed
-type Block  b = GBlock b IdNode
+type Header b = GBlock b Proxy
+type Block  b = GBlock b Identity
 
 
 data Locator b = Locator [BlockID b]

--- a/hschain-examples/HSChain/Mock/Types.hs
+++ b/hschain-examples/HSChain/Mock/Types.hs
@@ -79,8 +79,8 @@ makeGenesis
 makeGenesis dat stateHash valSet0 valSet1 = Block
   { blockHeight        = Height 0
   , blockPrevBlockID   = Nothing
-  , blockValidators    = merkled valSet0
-  , blockNewValidators = merkled valSet1
+  , blockValidators    = hashed valSet0
+  , blockNewValidators = hashed valSet1
   , blockData          = merkled dat
   , blockPrevCommit    = Nothing
   , blockEvidence      = merkled []

--- a/hschain-merkle/HSChain/Types/Merkle/Tree.hs
+++ b/hschain-merkle/HSChain/Types/Merkle/Tree.hs
@@ -144,15 +144,15 @@ checkMerkleProof rootH (MerkleProof a path)
     calcH = hash
           $ Just
           $ foldr step (Leaf a) path
-    step :: Either (Hash alg) (Hash alg) -> Node Hashed alg a -> Node Hashed alg a
-    step (Left  g) h = Branch (MerkleNode $ hashed h) (MerkleNode $ Hashed g)
-    step (Right g) h = Branch (MerkleNode $ Hashed g) (MerkleNode $ hashed h)
+    step :: Either (Hash alg) (Hash alg) -> Node Proxy alg a -> Node Proxy alg a
+    step (Left  g) h = Branch (fromHashed (hashed h)) (fromHashed $ Hashed g)
+    step (Right g) h = Branch (fromHashed (Hashed g)) (fromHashed $ hashed h)
 
 
 -- | Create proof of inclusion. Implementation is rather inefficient
 createMerkleProof
   :: (Eq a)
-  => MerkleBlockTree IdNode alg a
+  => MerkleBlockTree Identity alg a
   -> a
   -> Maybe (MerkleProof alg a)
 createMerkleProof (MerkleBlockTree mtree) a = do
@@ -172,7 +172,7 @@ createMerkleProof (MerkleBlockTree mtree) a = do
 
 -- | Check whether Merkle tree is balanced and in canonical form:
 --   depth of leaves does not decrease.
-isBalanced :: MerkleBlockTree IdNode alg a -> Bool
+isBalanced :: MerkleBlockTree Identity alg a -> Bool
 isBalanced =
   merkleBlockTree >>> merkleValue >>> \case
     Nothing   -> True

--- a/hschain-merkle/HSChain/Types/Merkle/Types.hs
+++ b/hschain-merkle/HSChain/Types/Merkle/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveFoldable             #-}
 {-# LANGUAGE DeriveGeneric              #-}
@@ -8,24 +9,30 @@
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 -- |
--- Type classes for working with heterogenoeus merkle trees where we
--- can nodes which have attached hash and could be abbreviated to hash
--- only.
+-- Type classes and data types for working with heterogenoeus merkle
+-- trees where we can nodes which have attached hash and could be
+-- abbreviated to hash only.
 module HSChain.Types.Merkle.Types (
     -- * Type classes
     IsMerkle(..)
   , MerkleMap(..)
     -- * Node of Merkle tree
-  , MerkleNode(..)
-  , merkleValue
+  , MerkleNode
+    -- ** Construction
+  , merkled
+  , fromHashed
+    -- ** Access
   , merkleHash
-  , merkleMaybeValue
+  , merkleHashed
+  , merkleValue
+  , merkleNodeValue
+  , mapMerkleNode
   , toHashedNode
-    -- ** Concrete node instantiations
-  , Hashed(..)
-  , OptNode
-  , IdNode
+    -- * Reexports
+  , Identity(..)
+  , Proxy(..)
     -- * Serialization helpers
   , MerkleSerialize(..)
   , toSerialisedRepr
@@ -35,8 +42,10 @@ module HSChain.Types.Merkle.Types (
 import Control.DeepSeq
 import qualified Codec.Serialise as CBOR
 import qualified Data.Aeson      as JSON
+import Data.Coerce
 import Data.Functor.Classes
-import Data.Function
+import Data.Functor.Identity
+import Data.Proxy
 import GHC.Generics (Generic)
 
 import HSChain.Crypto
@@ -46,127 +55,109 @@ import HSChain.Crypto
 -- Heterogeneous Merkle trees
 ----------------------------------------------------------------
 
--- | Type class for nodes of Merkle tree. Basically it's hash of value
---   and value itself which could be absent. There're three cases:
---   value is guaranteed to be present ('IdNode'), mayb or mayb not be
---   present ('OptNode') or only hash ('Hashed').
+-- | Node of Merkle tree. It stores hash of node and node value as @f
+--   a@ which could be present or missing depending on type of
+--   @f@. Common parametrizations are:
 --
---   These data types are not supposed to be used by itself instead
---   'MerkleNode' should be used.
---
---   Instances should have instance of 'CryptoHashable' and only use
---   hash of value for calculating hash of node:
---
---   > hash a == hash (merkleHash a)
-class IsMerkle f where
-  -- | Obtain cached hash of node.
-  merkleHashed :: f alg a -> Hashed alg a
-  -- | Create node from bare value
-  merkled     :: (CryptoHash alg, CryptoHashable a) => a -> f alg a
-  -- | Convert to node with optional value
-  toOptNode   :: f alg a -> OptNode alg a
-  -- | Convert node with optional value to hash
-  fromOptNode :: OptNode alg a -> Maybe (f alg a)
+-- > MerkleNode Identity - node that always have value
+-- > MerkleNode Maybe    - node that optionally has hash in it
+-- > MerkleNode Proxy    - node that has only hash
+data MerkleNode f alg a = MerkleNode
+  -- NOTE: Hash is lazy on purpose. We want to avoid computing it when
+  --       it's not needed. Since we store hash alongside with value
+  --       it should not leak.
+  (Hashed alg a)
+  !(f a)
 
-class MerkleMap b where
-  merkleMap :: IsMerkle f => (forall alg a. f alg a -> g alg a) -> b f -> b g
-
--- | Newtype wrapper for nodes of Merkle trees. It's used to provide
---   serialization instance and ensure that data encoded as one node
---   could be decoded as another node e.g. (IdNode → OptNode)
---
--- > MerkleNode IdNode   - node that always have value
--- > MerkleNode OptNode  - node that optionally has hash in it
--- > MerkleNode Hashed   - node that hash only hash
-newtype MerkleNode f alg a = MerkleNode { getMerkleNode :: f alg a }
-  deriving stock   Foldable
-  deriving newtype (IsMerkle)
-
--- | Extract value from node of Merkle tree
-merkleValue :: MerkleNode IdNode alg a -> a
-merkleValue (MerkleNode (IdNode _ a)) = a
-
--- | Extract value from any type of node of Merkle tree.
-merkleMaybeValue :: IsMerkle f => f alg a -> Maybe a
-merkleMaybeValue n = let OptNode _ a = toOptNode n in a
-
--- | Extract hash corresponding to node
-merkleHash :: IsMerkle f => f alg a -> Hash alg
-merkleHash f = let Hashed h = merkleHashed f in h
-
-toHashedNode :: IsMerkle f => MerkleNode f alg a -> MerkleNode Hashed alg a
-toHashedNode (MerkleNode f) = MerkleNode $ merkleHashed f
+instance Foldable f => Foldable (MerkleNode f alg) where
+  foldMap f (MerkleNode _ a) = foldMap f a
 
 -- | Eq uses hash comparison as optimization
 instance (IsMerkle f) => Eq (MerkleNode f alg a) where
-  (==) = (==) `on` merkleHash . getMerkleNode
+  MerkleNode h1 _ == MerkleNode h2 _ = h1 == h2
 
 -- | Ord however compares underlying types
-instance (Ord a, IsMerkle f, Ord1 (f alg)) => Ord (MerkleNode f alg a) where
-  compare = liftCompare compare `on` getMerkleNode
+instance (Ord a) => Ord (MerkleNode Identity alg a) where
+  compare (MerkleNode _ f1) (MerkleNode _ f2) = liftCompare compare f1 f2
 
-instance (Show a, Show1 (f alg)) => Show (MerkleNode f alg a) where
-  showsPrec i = liftShowsPrec showsPrec showList i . getMerkleNode
-
-instance (NFData a, NFData1 (f alg)) => NFData (MerkleNode f alg a) where
-  rnf = liftRnf rnf . getMerkleNode
-
-instance (CryptoHash alg, IsMerkle f) => CryptoHashable (MerkleNode f alg a) where
-  hashStep = hashStep . merkleHash . getMerkleNode
-
-
-----------------------------------------------------------------
--- Types for nodes
-----------------------------------------------------------------
-
--- | Node that contains actual value alognside with hash. It's
---   expected to be used primarily as type parameter to 'MerkleNode':
---   @MerkleNode IdNode@
-data IdNode  alg a = IdNode  (Hashed alg a) !a
-  deriving stock    (Show,Eq,Ord,Generic)
-  deriving anyclass (NFData)
-
--- | Node that /may/ contain value alognside with hash. It's
---   expected to be used primarily as type parameter to 'MerkleNode':
---   @MerkleNode OptNode@
-data OptNode alg a = OptNode (Hashed alg a) !(Maybe a)
-  deriving stock    (Show,Eq,Ord,Generic)
-  deriving anyclass (NFData)
-
-instance IsMerkle IdNode where
-  merkleHashed (IdNode h _) = h
-  merkled a = IdNode (hashed a) a
-  toOptNode   (IdNode  h a) = OptNode h (Just a)
-  fromOptNode (OptNode h a) = IdNode  h <$> a
-
-instance IsMerkle OptNode where
-  merkleHashed (OptNode h _) = h
-  merkled a = OptNode (hashed a) (Just a)
-  toOptNode   = id
-  fromOptNode = Just
-
-instance IsMerkle Hashed where
-  merkleHashed = id
-  merkled = hashed
-  toOptNode h = OptNode h Nothing
-  fromOptNode = Just . Hashed . merkleHash
-
-instance NFData1 (IdNode alg) where
-  liftRnf f (IdNode h a) = rnf h `seq` f a
-
-instance Show1 (IdNode alg) where
-  liftShowsPrec sh _ i (IdNode h a)
+instance (Show1 f, Show a) => Show (MerkleNode f alg a) where
+  showsPrec i (MerkleNode h f)
     = showParen (i >= 11)
-    $ showString "IdNode "
-    . showParen True (shows h)
-    . showChar ' '
-    . sh 11 a
+    $ showString "MerkleNode "
+    . showsPrec 11 h
+    . showString " "
+    . liftShowsPrec showsPrec showList 11 f
 
-instance Eq1 (IdNode alg) where
-  liftEq f (IdNode _ a) (IdNode _ b) = f a b
+instance (NFData a, NFData1 f) => NFData (MerkleNode f alg a) where
+  rnf (MerkleNode h f) = rnf h `seq` liftRnf rnf f
 
-instance Ord1 (IdNode alg) where
-  liftCompare f (IdNode _ a) (IdNode _ b) = f a b
+instance (CryptoHash alg, IsMerkle f) => CryptoHashable (MerkleNode f alg a) where  
+  hashStep = hashStep . merkleHash
+
+
+-- | Extract hash corresponding to node
+merkleHash :: MerkleNode f alg a -> Hash alg
+merkleHash (MerkleNode (Hashed h) _) = h
+
+-- | Extract hash corresponding to node which is tagged by type.
+merkleHashed :: MerkleNode f alg a -> Hashed alg a
+merkleHashed (MerkleNode h _) = h
+
+-- | Extract value from node of Merkle tree
+merkleValue :: MerkleNode Identity alg a -> a
+merkleValue = runIdentity . merkleNodeValue
+
+-- | Extract value from node of Merkle tree
+merkleNodeValue :: MerkleNode f alg a -> f a
+merkleNodeValue (MerkleNode _ a) = a
+
+
+-- | Create node from bare value. We (ab)ue 
+merkled :: (CryptoHash alg, CryptoHashable a, Applicative f) => a -> MerkleNode f alg a
+merkled a = MerkleNode (hashed a) (pure a)
+
+-- | Create node from only value 
+fromHashed :: Hashed alg a -> MerkleNode Proxy alg a
+fromHashed h = MerkleNode h Proxy
+
+
+-- | Apply natural transformation to the node value. Value couldn't be
+--   changed by transformation because of prametricity
+mapMerkleNode :: (forall x. f x -> g x) -> MerkleNode f alg a -> MerkleNode g alg a
+-- NOTE: See note in toHashedNode
+mapMerkleNode f (MerkleNode !h a) = MerkleNode h (f a)
+
+-- | Strip value from node
+toHashedNode :: MerkleNode f alg a -> MerkleNode Proxy alg a
+-- NOTE: We force hash in order to avoid space leak. Hash field is
+--       lazy and could keep refernce to possibly much larger object
+toHashedNode (MerkleNode !h _) = MerkleNode h Proxy
+
+
+-- | Type class for wrappers for nodes of Merkle tree. Basically
+--   there're 3 instances: @Identity@, @Maybe@, and @Proxy@. They
+--   represent possibilities that node is present, may be present, we
+--   have only hash.
+class Applicative f => IsMerkle f where
+  nodeToMaybe   :: f a -> Maybe a
+  nodeFromMaybe :: Maybe a -> Maybe (f a)
+
+instance IsMerkle Maybe where
+  nodeToMaybe   = id
+  nodeFromMaybe = Just
+
+instance IsMerkle Proxy where
+  nodeToMaybe   _ = Nothing
+  nodeFromMaybe _ = Just Proxy
+
+instance IsMerkle Identity where
+  nodeToMaybe   = Just . runIdentity
+  nodeFromMaybe = coerce
+
+class MerkleMap b where
+  merkleMap :: IsMerkle f => (forall a. f a -> g a) -> b f -> b g
+
+
 
 ----------------------------------------------------------------
 -- Serialization instances
@@ -179,28 +170,30 @@ data MerkleSerialize alg a
   deriving stock    (Show,Eq,Ord,Generic)
   deriving anyclass (CBOR.Serialise, JSON.FromJSON, JSON.ToJSON)
 
-toSerialisedRepr :: OptNode alg a -> MerkleSerialize alg a
-toSerialisedRepr (OptNode h Nothing ) = MerkleHash  h
-toSerialisedRepr (OptNode _ (Just a)) = MerkleValue a
+toSerialisedRepr :: IsMerkle f => MerkleNode f alg a -> MerkleSerialize alg a
+toSerialisedRepr (MerkleNode h f) =
+  case nodeToMaybe f of Nothing -> MerkleHash  h
+                        Just a  -> MerkleValue a
 
-fromSerializedRepr :: (CryptoHash alg, CryptoHashable a) => MerkleSerialize alg a -> OptNode alg a
-fromSerializedRepr (MerkleHash  h) = OptNode h Nothing
-fromSerializedRepr (MerkleValue a) = merkled a
+
+fromSerializedRepr :: (CryptoHash alg, CryptoHashable a) => MerkleSerialize alg a -> MerkleNode Maybe alg a
+fromSerializedRepr (MerkleHash  h) = MerkleNode h Nothing
+fromSerializedRepr (MerkleValue a) = MerkleNode (hashed a) (Just a)
 
 instance ( CryptoHash alg
          , CryptoHashable a
          , IsMerkle f
          , CBOR.Serialise a
          ) => CBOR.Serialise (MerkleNode f alg a) where
-  encode = CBOR.encode . toSerialisedRepr . toOptNode . getMerkleNode
+  encode = CBOR.encode . toSerialisedRepr . toMaybeNode
   decode = do
-    n <- CBOR.decode
-    case fromOptNode $ fromSerializedRepr n of
+    MerkleNode h mn <- fromSerializedRepr <$> CBOR.decode
+    case nodeFromMaybe mn of
       Nothing -> fail "Can't covert from optional node"
-      Just a  -> return $ MerkleNode a
+      Just a  -> return $ MerkleNode h a
 
 instance (JSON.ToJSON a, IsMerkle f) => JSON.ToJSON (MerkleNode f alg a) where
-  toJSON = JSON.toJSON . toSerialisedRepr . toOptNode . getMerkleNode
+  toJSON = JSON.toJSON . toSerialisedRepr . toMaybeNode
 
 instance ( CryptoHash alg
          , CryptoHashable a
@@ -208,7 +201,10 @@ instance ( CryptoHash alg
          , JSON.FromJSON a
          ) => JSON.FromJSON (MerkleNode f alg a) where
   parseJSON o = do
-    n <- JSON.parseJSON o
-    case fromOptNode $ fromSerializedRepr n of
+    MerkleNode h mn <- fromSerializedRepr <$> JSON.parseJSON o
+    case nodeFromMaybe mn of
       Nothing -> fail "Can't covert from optional node"
-      Just a  -> return $ MerkleNode a
+      Just a  -> return $ MerkleNode h a
+
+toMaybeNode :: IsMerkle f => MerkleNode f alg a -> MerkleNode Maybe alg a
+toMaybeNode (MerkleNode h f) = MerkleNode h (nodeToMaybe f)

--- a/hschain-merkle/test/TM/MerkleBlock.hs
+++ b/hschain-merkle/test/TM/MerkleBlock.hs
@@ -25,7 +25,7 @@ prop_MerkleBlockTree :: [Integer] -> Bool
 prop_MerkleBlockTree leaves
   = isBalanced tree
   where
-    tree :: MerkleBlockTree IdNode SHA512 Integer
+    tree :: MerkleBlockTree Identity SHA512 Integer
     tree = createMerkleTree leaves
 
 -- Computation with different wrappers give same result
@@ -33,16 +33,16 @@ prop_computeMerkleOpt :: [Integer] -> Bool
 prop_computeMerkleOpt leaves
   = merkleBlockTreeHash t1 == merkleBlockTreeHash t2
   where
-    t1 = createMerkleTree leaves :: MerkleBlockTree IdNode  SHA512 Integer
-    t2 = createMerkleTree leaves :: MerkleBlockTree OptNode SHA512 Integer
+    t1 = createMerkleTree leaves :: MerkleBlockTree Identity SHA512 Integer
+    t2 = createMerkleTree leaves :: MerkleBlockTree Maybe    SHA512 Integer
 
 -- Computation with different wrappers give same result
 prop_computeMerkleHashed :: [Integer] -> Bool
 prop_computeMerkleHashed leaves
   = merkleBlockTreeHash t1 == merkleBlockTreeHash t2
   where
-    t1 = createMerkleTree leaves :: MerkleBlockTree IdNode SHA512 Integer
-    t2 = createMerkleTree leaves :: MerkleBlockTree Hashed SHA512 Integer
+    t1 = createMerkleTree leaves :: MerkleBlockTree Identity SHA512 Integer
+    t2 = createMerkleTree leaves :: MerkleBlockTree Maybe    SHA512 Integer
 
   
 -- Check that merkle proofs are correct
@@ -53,6 +53,6 @@ prop_MerkleProofCorrect leaves
         | p <- proofs
         ]
   where
-    tree :: MerkleBlockTree IdNode SHA512 Integer
+    tree :: MerkleBlockTree Identity SHA512 Integer
     tree   = createMerkleTree leaves
     proofs = createMerkleProof tree <$> leaves

--- a/hschain-quickcheck/HSChain/Arbitrary/Instances.hs
+++ b/hschain-quickcheck/HSChain/Arbitrary/Instances.hs
@@ -95,7 +95,7 @@ instance StreamCypher cypher => Arbitrary (PubKeyBox key kdf cypher) where
 
 instance (CryptoHash alg, CryptoHashable a, IsMerkle f, Arbitrary a) => Arbitrary (MerkleNode f alg a) where
   arbitrary = merkled <$> arbitrary
-  shrink a  = case merkleMaybeValue a of
+  shrink a  = case nodeToMaybe $ merkleNodeValue a of
     Nothing -> []
     Just x  -> merkled <$> shrink x
 

--- a/hschain-types/HSChain/Types/Blockchain.hs
+++ b/hschain-types/HSChain/Types/Blockchain.hs
@@ -163,8 +163,8 @@ blockHash
 blockHash = BlockID . hashed
 
 
-type Block  = GBlock IdNode
-type Header = GBlock Hashed
+type Block  = GBlock Identity
+type Header = GBlock Proxy
 
 -- | Block of blockchain.
 data GBlock f a = Block
@@ -202,9 +202,9 @@ toHeader Block{..} = Block
 instance (IsMerkle f, Crypto (Alg a), CryptoHashable a, Serialise     a) => Serialise     (GBlock f a)
 instance (IsMerkle f, Crypto (Alg a), CryptoHashable a, JSON.FromJSON a) => JSON.FromJSON (GBlock f a)
 instance (IsMerkle f, Crypto (Alg a),                   JSON.ToJSON   a) => JSON.ToJSON   (GBlock f a)
-instance (NFData a, NFData1 (f (Alg a)), NFData (PublicKey (Alg a)))     => NFData (GBlock f a)
-deriving instance (CryptoHash (Alg a), Show1 (f (Alg a)), Show a) => Show (GBlock f a)
-deriving instance (Eq (PublicKey (Alg a)), IsMerkle f, Eq1 (f (Alg a)), Eq a) => Eq (GBlock f a)
+instance (NFData a, NFData1 f, NFData (PublicKey (Alg a)))     => NFData (GBlock f a)
+deriving instance (CryptoHash (Alg a), Show1 f, Show a) => Show (GBlock f a)
+deriving instance (Eq (PublicKey (Alg a)), IsMerkle f, Eq1 f, Eq a) => Eq (GBlock f a)
 
 
 
@@ -403,8 +403,8 @@ instance (CryptoHash (Alg a)) => CryptoHashable (Vote 'PreCommit a) where
 --   blockchain state, set of validators and something else.
 data BChEval a x = BChEval
   { bchValue        :: !x
-  , validatorSet    :: !(MerkleNode IdNode (Alg a) (ValidatorSet (Alg a)))
-  , blockchainState :: !(MerkleNode IdNode (Alg a) (BlockchainState a))
+  , validatorSet    :: !(MerkleNode Identity (Alg a) (ValidatorSet (Alg a)))
+  , blockchainState :: !(MerkleNode Identity (Alg a) (BlockchainState a))
   }
   deriving stock (Generic, Functor)
 
@@ -461,7 +461,7 @@ data NewBlock a = NewBlock
   , newBlockLastBID  :: !(BlockID a)
   , newBlockCommit   :: !(Maybe (Commit a))
   , newBlockEvidence :: ![ByzantineEvidence a]
-  , newBlockState    :: !(MerkleNode IdNode (Alg a) (BlockchainState a))
+  , newBlockState    :: !(MerkleNode Identity (Alg a) (BlockchainState a))
   , newBlockValSet   :: !(ValidatorSet (Alg a))
   }
 

--- a/hschain/HSChain/Store.hs
+++ b/hschain/HSChain/Store.hs
@@ -255,11 +255,11 @@ nullMempool = Mempool
 
 -- | Storage for blockchain state.
 data BChStore m a = BChStore
-  { bchCurrentState  :: m (Maybe Height, MerkleNode IdNode (Alg a) (BlockchainState a))
+  { bchCurrentState  :: m (Maybe Height, MerkleNode Identity (Alg a) (BlockchainState a))
   -- ^ Height of value stored in state
-  , bchStoreRetrieve :: Height -> m (Maybe (MerkleNode IdNode (Alg a) (BlockchainState a)))
+  , bchStoreRetrieve :: Height -> m (Maybe (MerkleNode Identity (Alg a) (BlockchainState a)))
   -- ^ Retrieve state for given height. It's generally not expected that
-  , bchStoreStore    :: Height -> MerkleNode IdNode (Alg a) (BlockchainState a) -> m ()
+  , bchStoreStore    :: Height -> MerkleNode Identity (Alg a) (BlockchainState a) -> m ()
   -- ^ Put blockchain state at given height into store
   }
 

--- a/hschain/HSChain/Store/Internal/BlockDB.hs
+++ b/hschain/HSChain/Store/Internal/BlockDB.hs
@@ -187,7 +187,7 @@ storeGenesis BChEval{..} = do
 
 storeBlob
   :: (Serialise b)
-  => MerkleNode IdNode (Alg a) b
+  => MerkleNode Identity (Alg a) b
   -> Query 'RW a Int64
 storeBlob x = do
   basicQuery "SELECT id FROM thm_cas WHERE hash = ?" (Only (CBORed h)) >>= \case
@@ -202,22 +202,22 @@ storeBlob x = do
 
 retrieveBlobByHash
   :: (Serialise b, CryptoHashable b, CryptoHash (Alg a))
-  => MerkleNode Hashed (Alg a) b
-  -> Query 'RO a (Maybe (MerkleNode IdNode (Alg a) b))
+  => MerkleNode Proxy (Alg a) b
+  -> Query 'RO a (Maybe (MerkleNode Identity (Alg a) b))
 retrieveBlobByHash x = do
   r <- singleQ "SELECT blob FROM thm_cas WHERE hash = ?" (Only $ CBORed $ merkleHashed x)
   return $ merkled <$> r
 
 mustRetrieveBlobByHash
   :: (Serialise b, CryptoHashable b, CryptoHash (Alg a))
-  => MerkleNode Hashed (Alg a) b
-  -> Query 'RO a (MerkleNode IdNode (Alg a) b)
+  => MerkleNode Proxy (Alg a) b
+  -> Query 'RO a (MerkleNode Identity (Alg a) b)
 mustRetrieveBlobByHash = throwNothing DBMissingBlob <=< retrieveBlobByHash
 
 retrieveBlobByID
   :: (Serialise b, CryptoHashable b, CryptoHash (Alg a))
   => Int64
-  -> Query 'RO a (Maybe (MerkleNode IdNode (Alg a) b))
+  -> Query 'RO a (Maybe (MerkleNode Identity (Alg a) b))
 retrieveBlobByID i = do
   r <- singleQ "SELECT blob FROM thm_cas WHERE id = ?" (Only i)
   return $ merkled <$> r
@@ -225,7 +225,7 @@ retrieveBlobByID i = do
 mustRetrieveBlobByID
   :: (Serialise b, CryptoHashable b, CryptoHash (Alg a))
   => Int64
-  -> Query 'RO a (MerkleNode IdNode (Alg a) b)
+  -> Query 'RO a (MerkleNode Identity (Alg a) b)
 mustRetrieveBlobByID = throwNothing DBMissingBlob <=< retrieveBlobByID
 
 
@@ -402,7 +402,7 @@ storeCommitWrk mcmt blk = liftQueryRW $ do
 
 storeValSet
   :: (Crypto (Alg a), MonadQueryRW m a)
-  => Height -> MerkleNode IdNode (Alg a) (ValidatorSet (Alg a)) -> m ()
+  => Height -> MerkleNode Identity (Alg a) (ValidatorSet (Alg a)) -> m ()
 storeValSet h vals = liftQueryRW $ do
   i <- storeBlob vals
   basicExecute "INSERT INTO thm_validators VALUES (?,?)" (h, i)

--- a/hschain/HSChain/Store/STM.hs
+++ b/hschain/HSChain/Store/STM.hs
@@ -183,7 +183,7 @@ newMempool validation = do
 -- | Create new storage for blockchain 
 newSTMBchStorage
   :: (MonadIO m)
-  => MerkleNode IdNode (Alg a) (BlockchainState a) -> m (BChStore m a)
+  => MerkleNode Identity (Alg a) (BlockchainState a) -> m (BChStore m a)
 newSTMBchStorage st0 = do
   varSt <- liftIO $ newTVarIO (Nothing, st0)
   return BChStore


### PR DESCRIPTION
Idea is to factor out hash from three data types:

> IdNode | OptNode | Hashed

and replace it

> Hash · (Identity | Maybe | Proxy)

Kind and instance contexts become much simpler as result. In hindsight it's
obvious solution to the point: how could one do it differently?!

Idea due to @thesz