### PR TITLE
Preparation for time handling in PoW blockchain

### DIFF
--- a/hschain-PoW/HSChain/Examples/Simple.hs
+++ b/hschain-PoW/HSChain/Examples/Simple.hs
@@ -47,6 +47,6 @@ instance BlockData KV where
 
   --
   blockID b = let Hashed h = hashed b in KV'BID h
-  validateHeader _  = return True
+  validateHeader _ _ _ = return True
   validateBlock  _  = return True
   blockWork         = Work . fromIntegral . kvSolution . blockData

--- a/hschain-PoW/HSChain/PoW/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/Consensus.hs
@@ -290,7 +290,8 @@ processHeader header = do
   -- Perform header validations
   unless (succ (bhHeight parent) == blockHeight header)
     $ throwError ErrH'HeightMismatch
-  goodHeader <- validateHeader header
+  now <- getCurrentTime
+  goodHeader <- validateHeader parent now header
   unless goodHeader
     $ throwError ErrH'ValidationFailure
   -- Create new index entry

--- a/hschain-PoW/HSChain/PoW/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/Consensus.hs
@@ -119,6 +119,7 @@ blockIndexFromGenesis genesis
   where
     bid = blockID genesis
     bh  = BH { bhHeight   = Height 0
+             , bhTime     = blockTime genesis
              , bhBID      = bid
              , bhWork     = blockWork genesis
              , bhPrevious = Nothing
@@ -136,6 +137,7 @@ insertIdx bh (BlockIndex idx) = BlockIndex $ Map.insert (bhBID bh) bh idx
 --   since we'll keep many thousands on these values in memory.
 data BH b = BH
   { bhHeight   :: !Height         --
+  , bhTime     :: !Time
   , bhBID      :: !(BlockID b)    --
   , bhWork     :: !Work           --
   , bhPrevious :: !(Maybe (BH b)) --
@@ -145,6 +147,7 @@ data BH b = BH
 asHeader :: BH b -> Header b
 asHeader bh = GBlock
   { blockHeight   = bhHeight bh
+  , blockTime   = bhTime bh
   , prevBlock     = bhBID <$> bhPrevious bh
   , blockData     = bhData bh
   }
@@ -318,6 +321,7 @@ processHeader header = do
   -- Create new index entry
   let work = bhWork parent <> blockWork header
       bh   = BH { bhHeight   = blockHeight header
+                , bhTime     = blockTime   header
                 , bhBID      = bid
                 , bhWork     = work
                 , bhPrevious = Just parent

--- a/hschain-PoW/HSChain/PoW/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/Consensus.hs
@@ -132,31 +132,6 @@ lookupIdx bid (BlockIndex idx) = Map.lookup bid idx
 insertIdx :: (Ord (BlockID b)) => BH b -> BlockIndex b -> BlockIndex b
 insertIdx bh (BlockIndex idx) = BlockIndex $ Map.insert (bhBID bh) bh idx
 
--- | Unpacked header for storage in block index. We use this data type
---   instead of @[(BlockID, Header b)]@ in order to reduce memory use
---   since we'll keep many thousands on these values in memory.
-data BH b = BH
-  { bhHeight   :: !Height         --
-  , bhTime     :: !Time
-  , bhBID      :: !(BlockID b)    --
-  , bhWork     :: !Work           --
-  , bhPrevious :: !(Maybe (BH b)) --
-  , bhData     :: !(b Proxy)      --
-  }
-
-asHeader :: BH b -> Header b
-asHeader bh = GBlock
-  { blockHeight   = bhHeight bh
-  , blockTime   = bhTime bh
-  , prevBlock     = bhBID <$> bhPrevious bh
-  , blockData     = bhData bh
-  }
-
-deriving instance (Show (BlockID b), Show (b Proxy)) => Show (BH b)
-
-instance BlockData b => Eq (BH b) where
-  a == b = bhBID a == bhBID b
-
 makeLocator :: BH b -> Locator b
 makeLocator  = Locator . takeH 10 . Just
   where

--- a/hschain-PoW/HSChain/PoW/P2P.hs
+++ b/hschain-PoW/HSChain/PoW/P2P.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleContexts           #-}
@@ -68,7 +69,7 @@ startNode cfg netAPI seeds db consensus = do
     }
   return PoW
     { currentConsensus = readTVar bIdx
-    , sendNewBlock     = \b -> runExceptT $ do
+    , sendNewBlock     = \(!b) -> runExceptT $ do
         res <- liftIO newEmptyMVar
         sinkIO sinkBOX $ BoxRX $ \cnt -> liftIO . putMVar res =<< cnt (RxMined b)
         void $ liftIO $ takeMVar res

--- a/hschain-PoW/HSChain/PoW/P2P.hs
+++ b/hschain-PoW/HSChain/PoW/P2P.hs
@@ -70,12 +70,8 @@ startNode cfg netAPI seeds db consensus = do
     { currentConsensus = readTVar bIdx
     , sendNewBlock     = \b -> runExceptT $ do
         res <- liftIO newEmptyMVar
-        sinkIO sinkBOX $ BoxRX $ \cnt -> liftIO . putMVar res =<< cnt (RxHeaders [toHeader b])
-        liftIO (takeMVar res) >>= \case
-          Peer'Punish e     -> throwError (toException e)
-          Peer'EnterCatchup -> return ()
-          Peer'Noop         -> return ()
-        sinkIO sinkBOX $ BoxRX $ \cnt -> void $ cnt $ RxBlock b
+        sinkIO sinkBOX $ BoxRX $ \cnt -> liftIO . putMVar res =<< cnt (RxMined b)
+        void $ liftIO $ takeMVar res
     }
 
 

--- a/hschain-PoW/HSChain/PoW/P2P.hs
+++ b/hschain-PoW/HSChain/PoW/P2P.hs
@@ -61,7 +61,7 @@ startNode cfg netAPI seeds db consensus = do
   bIdx                    <- liftIO $ newTVarIO consensus
   runPEX cfg netAPI seeds blockReg sinkBOX mkSrcAnn (readTVar bIdx) db
   -- Consensus thread
-  cfork $ threadConsensus db consensus ConsensusCh
+  cforkLinked $ threadConsensus db consensus ConsensusCh
     { bcastAnnounce   = sinkAnn
     , sinkConsensusSt = Sink $ writeTVar bIdx
     , sinkReqBlocks   = sinkBIDs
@@ -74,7 +74,3 @@ startNode cfg netAPI seeds db consensus = do
         sinkIO sinkBOX $ BoxRX $ \cnt -> liftIO . putMVar res =<< cnt (RxMined b)
         void $ liftIO $ takeMVar res
     }
-
-
-cfork :: (MonadMask m, MonadFork m) => m a -> ContT b m ()
-cfork action = ContT $ \cnt -> forkLinked action (cnt ())

--- a/hschain-PoW/HSChain/PoW/P2P/Handler/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Handler/Consensus.hs
@@ -69,11 +69,18 @@ consensusMonitor
 consensusMonitor db (BoxRX message)
   = message $ logR <=< \case
       RxAnn     m  -> handleAnnounce m
-      RxBlock   b  -> handleBlock    b
+      RxBlock   b  -> do
+        lift $ logger DebugS "Got RxBlock" (sl "bid" (blockID b))
+        evalError $ handleBlockError $ processBlock db b
+      RxMined   b  -> do
+        lift $ logger DebugS "Got RxMined" (sl "bid" (blockID b))
+        evalError $ do handleHeaderError $ processHeader (toHeader b)
+                       handleBlockError  $ processBlock  db b
       RxHeaders hs -> do
         lift $ logger DebugS "Got RxHeaders" (sl "bid" (blockID <$> hs))
-        handleHeaders hs
+        evalError $ mapM_ (handleHeaderError . processHeader) hs
   where
+    -- Log out responce to peer
     logR m = do lift $ logger DebugS "Resp" (sl "v" (show m))
                 return m
     -- Handler for announces coming from peers (they come unrequested)
@@ -91,24 +98,24 @@ consensusMonitor db (BoxRX message)
           -- We got announce that we couldn't attach to block tree. So
           -- we need that peer to catch up
           ErrH'UnknownParent     -> return Peer'EnterCatchup
-    -- Handle block that we got from peer
-    --
-    -- FIXME: Handle announcements
-    handleBlock b = do
-      lift $ logger DebugS "Got RxBlock" (sl "bid" (blockID b))
-      runExceptT (processBlock db b) >>= \case
-        Right () -> return Peer'Noop
-        Left  e  -> case e of
-          ErrB'UnknownBlock -> error "Impossible: we should'n get unknown block"
-          ErrB'InvalidBlock -> return Peer'Noop
-    -- Handle headers that we got from peer.
-    handleHeaders [] = return Peer'Noop
-    handleHeaders (h:hs) = do
-      runExceptT (processHeader h) >>= \case
-        Right () -> handleHeaders hs
-        Left  e  -> case e of
-          ErrH'KnownHeader       -> handleHeaders hs
-          ErrH'HeightMismatch    -> return $ Peer'Punish $ toException e
-          ErrH'UnknownParent     -> return $ Peer'Punish $ toException e
-          ErrH'ValidationFailure -> return $ Peer'Punish $ toException e
-          ErrH'BadParent         -> return $ Peer'Punish $ toException e
+    -- Handle error conditions which happen when we process new block
+    -- Note that we explicitly requrest blocks by their BIDs so we
+    -- shouln't punish peers
+    handleBlockError = mapExceptT $ fmap $ \case
+      Right               () -> Right ()
+      Left ErrB'UnknownBlock -> error "Impossible: we should'n get unknown block"
+      Left ErrB'InvalidBlock -> Right ()
+    -- Handle errors during header processing. Not that KnownHeader is
+    -- not really an error
+    handleHeaderError = mapExceptT $ fmap $ \case
+      Right () -> Right ()
+      Left  e  -> case e of
+        ErrH'KnownHeader       -> Right ()
+        ErrH'HeightMismatch    -> Left $ Peer'Punish $ toException e
+        ErrH'UnknownParent     -> Left $ Peer'Punish $ toException e
+        ErrH'ValidationFailure -> Left $ Peer'Punish $ toException e
+        ErrH'BadParent         -> Left $ Peer'Punish $ toException e
+    -- Convert error from ExceptT
+    evalError action = runExceptT action >>= \case
+      Right () -> return Peer'Noop
+      Left  e  -> return e

--- a/hschain-PoW/HSChain/PoW/P2P/Handler/Peer.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Handler/Peer.hs
@@ -60,6 +60,9 @@ runPeer conn chans@PeerChans{..} = logOnException $ do
                     peersBestHead   <- newTVarIO Nothing
                     inCatchup       <- newTVarIO False
                     return PeerState{..}
+  -- Send announce with current state at start
+  do s <- atomicallyIO peerConsensuSt
+     sinkIO sinkGossip $ GossipAnn $ AnnBestHead $ s ^. bestHead . _1 . to asHeader
   runConcurrently
     [ peerSend    conn (srcGossip <> fmap GossipAnn peerBCastAnn)
     , peerRecv    conn     st chans sinkGossip

--- a/hschain-PoW/HSChain/PoW/P2P/Types.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Types.hs
@@ -164,6 +164,9 @@ instance ( JSON.ToJSON (BlockID b)
 data MsgRX b
   = RxAnn     !(MsgAnn b)  -- ^ Announcement from peer
   | RxBlock   !(Block b)   -- ^ Peer sent block to us
+  | RxMined   !(Block b)   -- ^ Freshly mined block. It's different
+                           --   from RxBlock in that we'll accept
+                           --   block even if we don't have its header.
   | RxHeaders [Header b]   -- ^ Peer sent headers to us
 
 -- | Box wrapping message to consensus. 

--- a/hschain-PoW/HSChain/PoW/Types.hs
+++ b/hschain-PoW/HSChain/PoW/Types.hs
@@ -96,6 +96,7 @@ class ( Show      (BlockID b)
 --   (usually block is Merkle tree of some transactions)
 data GBlock b f = GBlock
   { blockHeight   :: !Height
+  , blockTime   :: !Time
   , prevBlock     :: !(Maybe (BlockID b))
   , blockData     :: !(b f)
   }

--- a/hschain-PoW/HSChain/PoW/Types.hs
+++ b/hschain-PoW/HSChain/PoW/Types.hs
@@ -82,10 +82,13 @@ class ( Show      (BlockID b)
 
   -- | Compute block ID out of block using only header.
   blockID :: IsMerkle f => GBlock b f -> BlockID b
-  -- | Context free validation of header. It's mostly sanity check on
-  --   header. 
-  validateHeader :: MonadIO m => Header b -> m Bool
+  -- | Validate header. Chain ending with parent block and current
+  --   time are provided as parameters.
+  validateHeader :: MonadIO m => BH b -> Time -> Header b -> m Bool
+  -- | Context free validation of block which doesn't have access to
+  --   state of blockchain. It should perform sanity checks.
   validateBlock  :: MonadIO m => Block  b -> m Bool
+  -- | Amount of work in the block
   blockWork      :: GBlock b f -> Work
 
 -- | Generic block. This is just spine of blockchain, that is height

--- a/hschain-PoW/test/TM/P2P.hs
+++ b/hschain-PoW/test/TM/P2P.hs
@@ -140,7 +140,9 @@ runNetTest test = do
       send $ serialise $ HandshakeHello (HandshakeNonce 0) port
       HandshakeAck <- deserialise <$> recv
       -- Run test
-      runTestM conn test
+      runTestM conn $ do
+        GossipAnn (AnnBestHead _) <- recvM
+        test
   where
     ipNode = NetAddrV4 1 port
     ipOur  = NetAddrV4 2 port

--- a/hschain-PoW/test/TM/Util/Mockchain.hs
+++ b/hschain-PoW/test/TM/Util/Mockchain.hs
@@ -16,6 +16,7 @@ mockchain :: [Block KV]
 mockchain = gen : unfoldr (Just . (\b -> (b,b)) . mineBlock "VAL") gen
   where
     gen = GBlock { blockHeight = Height 0
+                 , blockTime   = Time 0
                  , prevBlock   = Nothing
                  , blockData   = KV { kvData = merkled [], kvSolution = 1 }
                  }
@@ -23,6 +24,7 @@ mockchain = gen : unfoldr (Just . (\b -> (b,b)) . mineBlock "VAL") gen
 mineBlock :: String -> Block KV -> Block KV
 mineBlock val b = GBlock
   { blockHeight = succ $ blockHeight b
+  , blockTime   = Time 0
   , prevBlock   = Just $! blockID b
   , blockData   = KV { kvData = merkled [ let Height h = blockHeight b
                                           in (fromIntegral h, val)


### PR DESCRIPTION
This PR all prerequisites for working with time and adjustments of mining difficulty, And miscellaneous bug fixes/improvements

 - Time field is added to GBlock
 - Header validation takes time parameter. It's needed in order to reject blocks from the future (not implemented yet)
 - `BH` data type is moved to `HSChain.PoW.Types` since we need to pass ancestor chain to the block validation in order to compute difficulty adjustments
 - `RxMined` message added as an optimization. This way mined block is processed atomically and node doesn't proceed to ask other nodes about freshly mined block they obviously don't have
 - Block is forced to WHNF in `sendNewBlock`
 - Peer sends announce immediately on connection which enables immediate sync