### PR TITLE
Implement difficulty adjustment for the KV node

### DIFF
--- a/hschain-PoW/HSChain/Examples/Simple.hs
+++ b/hschain-PoW/HSChain/Examples/Simple.hs
@@ -2,16 +2,32 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 -- |
---
-module HSChain.Examples.Simple where
+-- Simple block which implements write only key-value storage. It's
+-- only use is to test and debug PoW algorithms.
+module HSChain.Examples.Simple
+  ( KV(..)
+  , KVConfig(..)
+  , retarget
+  , mine
+  ) where
 
 import Codec.Serialise      (Serialise)
+import Control.Applicative
+import Control.Monad
+import Data.Bits
 import Data.Functor.Classes (Show1)
-import qualified Data.Aeson as JSON
+import Data.List            (find)
+import Data.Word
+import qualified Data.Aeson      as JSON
+import qualified Data.ByteString as BS
+import Numeric.Natural
 import GHC.Generics         (Generic)
 
 import HSChain.Crypto
@@ -23,30 +39,104 @@ import HSChain.PoW.Types
 
 ----------------------------------------------------------------
 --
+----------------------------------------------------------------
 
-data KV f = KV
-  { kvData     :: MerkleNode f SHA256 [(Int,String)]
-  , kvSolution :: Integer
+-- | Simple block which contains key-value pairs. Work function is
+--   simple SHA256 a la bitcoin
+data KV cfg f = KV
+  { kvData       :: !(MerkleNode f SHA256 [(Int,String)])
+  -- ^ List of key-value pairs
+  , kvNonce      :: !Word32
+  -- ^ Nonce which is used to get
+  , kvDifficulty :: !Natural
+  -- ^ Current difficulty of mining. It means that
+  --   @SHA256(block) < 2^256 / kvDifficulty@
   }
   deriving stock (Generic)
-deriving stock instance Show1    f => Show (KV f)
-deriving stock instance IsMerkle f => Eq   (KV f)
-instance Serialise (KV Identity)
-instance Serialise (KV Proxy)
+deriving stock instance Show1    f => Show (KV cfg f)
+deriving stock instance IsMerkle f => Eq   (KV cfg f)
+instance Serialise (KV cfg Identity)
+instance Serialise (KV cfg Proxy)
 
-
-instance IsMerkle f => CryptoHashable (KV f) where
+instance IsMerkle f => CryptoHashable (KV cfg f) where
   hashStep = genericHashStep "hschain"
 
-instance MerkleMap KV where
-  merkleMap f (KV d w) = KV (mapMerkleNode f d) w
+instance MerkleMap (KV cfg) where
+  merkleMap f KV{..} = KV { kvData = mapMerkleNode f kvData
+                          , ..
+                          }
 
-instance BlockData KV where
-  newtype BlockID KV = KV'BID (Hash SHA256)
+
+-- | We may need multiple chains (main chain, test chain(s)) which may
+--   use different difficulty adjustment algorithms etc.
+class KVConfig cfg where
+  -- | Difficulty adjustment is performed every N of blocks
+  kvAdjustInterval :: Const Height  cfg
+  -- | Expected interval between blocks in milliseconds
+  kvBlockInterval  :: Const Natural cfg
+
+
+instance KVConfig cfg => BlockData (KV cfg) where
+  newtype BlockID (KV cfg) = KV'BID (Hash SHA256)
     deriving newtype (Show,Eq,Ord,CryptoHashable,Serialise, JSON.ToJSON, JSON.FromJSON)
-
   --
-  blockID b = let Hashed h = hashed b in KV'BID h
-  validateHeader _ _ _ = return True
-  validateBlock  _  = return True
-  blockWork         = Work . fromIntegral . kvSolution . blockData
+  blockID = KV'BID . hash
+  --
+  validateHeader bh (Time now) header
+    = return
+    $ and
+    [ hash256 header <= blockTarget header
+    , kvDifficulty (blockData header) == retarget bh
+    -- Time checks
+    , t <= now + (2*60*60*1000)
+    -- FIXME: Check that we're ahead of median time of N prev block
+    ]
+    where
+      Time t = blockTime header
+  --
+  validateBlock  _ = return True
+  blockWork      b = Work $ kvDifficulty $ blockData b
+
+
+blockTarget :: GBlock (KV cfg) f -> Natural
+blockTarget b = 2^(256::Int) `div` kvDifficulty (blockData b)
+
+-- | Compute difficulty of next block
+retarget :: forall cfg. KVConfig cfg => BH (KV cfg) -> Natural
+retarget bh
+  | bhHeight bh `mod` interval == 0
+  , Just old <- goBack interval bh
+  , bhHeight old /= 0
+  =   let Time t1 = bhTime old
+          Time t2 = bhTime bh
+          tgt     = 2^(256::Int) `div` kvDifficulty (bhData bh)
+          tgt'    = (tgt * fromIntegral (t2 - t1)) `div` (fromIntegral interval * delay)
+      in 2^(256::Int) `div` tgt'
+  | otherwise
+    = kvDifficulty $ bhData bh
+  where
+    interval = getConst (kvAdjustInterval @cfg)
+    delay    = getConst (kvBlockInterval  @cfg)
+
+-- SHA256 as 256-bit number (not terrbly efficient)
+hash256 :: CryptoHashable a => a -> Natural
+hash256 a
+  = BS.foldl' (\i w -> (i `shiftL` 8) + fromIntegral  w) 0 bs
+  where
+    Hash bs = hash a :: Hash SHA256
+
+-- | Mine new block. Not very efficicent but will do for debugging
+mine :: Block (KV cfg) -> Maybe (Block (KV cfg))
+mine b0 = find (\b -> hash256 b <= tgt)
+  [ let GBlock{..} = b0
+    in  GBlock{ blockData = blockData { kvNonce = nonce }
+              , ..
+              }
+  | nonce <- [minBound .. maxBound]
+  ]
+  where
+    tgt = blockTarget b0
+
+goBack :: Height -> BH b -> Maybe (BH b)
+goBack (Height 0) = Just
+goBack h          = goBack (pred h) <=< bhPrevious

--- a/hschain-PoW/HSChain/Examples/Util.hs
+++ b/hschain-PoW/HSChain/Examples/Util.hs
@@ -31,7 +31,7 @@ inMemoryView step = make (error "No revinding past genesis")
           , flushState  = return ()
           }
 
-viewKV :: Monad m => BlockID KV -> StateView m KV
+viewKV :: (KVConfig cfg, Monad m) => BlockID (KV cfg) -> StateView m (KV cfg)
 viewKV bid = inMemoryView step Map.empty bid
   where
     step b m

--- a/hschain-PoW/HSChain/PoW/P2P.hs
+++ b/hschain-PoW/HSChain/PoW/P2P.hs
@@ -36,6 +36,7 @@ import HSChain.Types.Merkle.Types
 data PoW m b = PoW
   { currentConsensus :: STM (Consensus m b)
   , sendNewBlock     :: Block b -> m (Either SomeException ())
+  , chainUpdate      :: STM (Src (BH b, StateView m b))
   }
 
 
@@ -54,18 +55,20 @@ startNode
   -> ContT r m (PoW m b)
 startNode cfg netAPI seeds db consensus = do
   lift $ logger InfoS "Starting PoW node" ()
-  (sinkBOX,    srcBOX)    <- queuePair
-  (sinkAnn,    mkSrcAnn)  <- broadcastPair
-  (sinkBIDs,   srcBIDs)   <- queuePair
-  blockReg                <- newBlockRegistry srcBIDs
-  bIdx                    <- liftIO $ newTVarIO consensus
+  (sinkBOX,    srcBOX)     <- queuePair
+  (sinkAnn,    mkSrcAnn)   <- broadcastPair
+  (sinkChain,  mkSrcChain) <- broadcastPair
+  (sinkBIDs,   srcBIDs)    <- queuePair
+  blockReg                 <- newBlockRegistry srcBIDs
+  bIdx                     <- liftIO $ newTVarIO consensus
   runPEX cfg netAPI seeds blockReg sinkBOX mkSrcAnn (readTVar bIdx) db
   -- Consensus thread
   cforkLinked $ threadConsensus db consensus ConsensusCh
-    { bcastAnnounce   = sinkAnn
-    , sinkConsensusSt = Sink $ writeTVar bIdx
-    , sinkReqBlocks   = sinkBIDs
-    , srcRX           = srcBOX
+    { bcastAnnounce    = sinkAnn
+    , bcastChainUpdate = sinkChain
+    , sinkConsensusSt  = Sink $ writeTVar bIdx
+    , sinkReqBlocks    = sinkBIDs
+    , srcRX            = srcBOX
     }
   return PoW
     { currentConsensus = readTVar bIdx
@@ -73,4 +76,5 @@ startNode cfg netAPI seeds db consensus = do
         res <- liftIO newEmptyMVar
         sinkIO sinkBOX $ BoxRX $ \cnt -> liftIO . putMVar res =<< cnt (RxMined b)
         void $ liftIO $ takeMVar res
+    , chainUpdate = mkSrcChain
     }

--- a/hschain-PoW/HSChain/PoW/P2P/Handler/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Handler/Consensus.hs
@@ -34,10 +34,11 @@ import HSChain.PoW.Logger
 
 -- | Channels for sending data to and from consensus thread
 data ConsensusCh m b = ConsensusCh
-  { bcastAnnounce   :: Sink (MsgAnn b)
-  , sinkConsensusSt :: Sink (Consensus m b)
-  , sinkReqBlocks   :: Sink (Set (BlockID b))
-  , srcRX           :: Src  (BoxRX m b)
+  { bcastAnnounce    :: Sink (MsgAnn b)
+  , bcastChainUpdate :: Sink (BH b, StateView m b)
+  , sinkConsensusSt  :: Sink (Consensus m b)
+  , sinkReqBlocks    :: Sink (Set (BlockID b))
+  , srcRX            :: Src  (BoxRX m b)
   }
 
 -- | Thread that reacts to messages from peers and updates consensus
@@ -56,8 +57,10 @@ threadConsensus db consensus0 ConsensusCh{..} = descendNamespace "cns" $ logOnEx
          consensusMonitor db =<< awaitIO srcRX
          sinkIO sinkConsensusSt =<< get
          sinkIO sinkReqBlocks   =<< use requiredBlocks
-         bh' <- use $ bestHead . _1
-         when (bhBID bh /= bhBID bh') $ sinkIO bcastAnnounce $ AnnBestHead $ asHeader bh'
+         (bh',st,_) <- use bestHead
+         when (bhBID bh /= bhBID bh') $ do
+           sinkIO bcastAnnounce $ AnnBestHead $ asHeader bh'
+           sinkIO bcastChainUpdate (bh',st)
 
 
 -- Handler for messages coming from peer.

--- a/hschain-PoW/HSChain/PoW/Types.hs
+++ b/hschain-PoW/HSChain/PoW/Types.hs
@@ -37,13 +37,16 @@ import HSChain.Types.Merkle.Types
 -- | Height of block in blockchain. That is 
 newtype Height = Height Int32
   deriving stock   (Show, Read, Generic, Eq, Ord)
-  deriving newtype (NFData, CBOR.Serialise, JSON.ToJSON, JSON.FromJSON, Enum, CryptoHashable)
+  deriving newtype ( NFData, Num, Real, Integral
+                   , CBOR.Serialise, JSON.ToJSON, JSON.FromJSON, Enum, CryptoHashable)
 
 -- | Time in milliseconds since UNIX epoch.
 newtype Time = Time Int64
-  deriving stock   (Show, Read, Generic, Eq, Ord)
+  deriving stock   (Read, Generic, Eq, Ord)
   deriving newtype (NFData, CBOR.Serialise, JSON.ToJSON, JSON.FromJSON, Enum, CryptoHashable)
 
+instance Show Time where
+  show = show . timeToUTC
 
 -- | Get current time
 getCurrentTime :: MonadIO m => m Time
@@ -79,7 +82,6 @@ class ( Show      (BlockID b)
   -- | ID of block. Usually it should be just a hash but we want to
   --   leave some representation leeway for implementations. 
   data BlockID b
-
   -- | Compute block ID out of block using only header.
   blockID :: IsMerkle f => GBlock b f -> BlockID b
   -- | Validate header. Chain ending with parent block and current

--- a/hschain-PoW/test/TM/Util/Mockchain.hs
+++ b/hschain-PoW/test/TM/Util/Mockchain.hs
@@ -1,45 +1,56 @@
 -- |
 module TM.Util.Mockchain where
 
-import Data.List (unfoldr)
+import Control.Applicative
+import Data.Maybe (fromJust)
+import Data.List  (unfoldr)
 
 import HSChain.PoW.Types
 import HSChain.Types.Merkle.Types
 import HSChain.Examples.Simple
 
-
 ----------------------------------------------------------------
 --
 ----------------------------------------------------------------
 
-mockchain :: [Block KV]
+mockchain :: KVConfig cfg => [Block (KV cfg)]
 mockchain = gen : unfoldr (Just . (\b -> (b,b)) . mineBlock "VAL") gen
   where
     gen = GBlock { blockHeight = Height 0
                  , blockTime   = Time 0
                  , prevBlock   = Nothing
-                 , blockData   = KV { kvData = merkled [], kvSolution = 1 }
+                 , blockData   = KV { kvData       = merkled []
+                                    , kvNonce      = 0
+                                    , kvDifficulty = 256
+                                    }
                  }
 
-mineBlock :: String -> Block KV -> Block KV
-mineBlock val b = GBlock
+mineBlock :: KVConfig cfg => String -> Block (KV cfg) -> Block (KV cfg)
+mineBlock val b = fromJust $ mine $ GBlock
   { blockHeight = succ $ blockHeight b
   , blockTime   = Time 0
   , prevBlock   = Just $! blockID b
   , blockData   = KV { kvData = merkled [ let Height h = blockHeight b
                                           in (fromIntegral h, val)
                                         ]
-                     , kvSolution = fromIntegral $ fromEnum $ succ $ blockHeight b
+                     , kvNonce      = 0
+                     , kvDifficulty = kvDifficulty (blockData b)
                      }
   }
 
 
-genesis,block1,block2,block3,block2' :: Block KV
-genesis:block1:block2:block3:_ = take 4 mockchain
+data MockChain
+
+instance KVConfig MockChain where
+  kvAdjustInterval = Const 100
+  kvBlockInterval  = Const 1000
+
+genesis,block1,block2,block3,block2' :: Block (KV MockChain)
+genesis:block1:block2:block3:_ = mockchain
 block2' = mineBlock "Z" block1
 
 
-header1,header2,header3,header2' :: Header KV
+header1,header2,header3,header2' :: Header (KV MockChain)
 header1  = toHeader block1
 header2  = toHeader block2
 header3  = toHeader block3


### PR DESCRIPTION
Now KV example uses simple bitcoin-like work function (SHA256 of block) and
difficult adjustment algorithm copied from bitcoin as well.

NOTE TM.P2P.testCatchup is broken by this change but these tests need some
     rework anyway