### PR TITLE
Split examples into examples and -types package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,6 +10,7 @@ packages:
          hschain-net
          hschain-quickcheck
          hschain-examples
+         hschain-examples-types
          serialise-cddl
          proof-of-work
 

--- a/hschain-examples-types/HSChain/Mock/Coin/Types.hs
+++ b/hschain-examples-types/HSChain/Mock/Coin/Types.hs
@@ -1,0 +1,246 @@
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+-- |
+module HSChain.Mock.Coin.Types where
+
+import Control.Monad
+import Control.Monad.Catch
+import Control.DeepSeq
+import Codec.Serialise      (Serialise)
+import qualified Data.Aeson as JSON
+import Data.Foldable
+import Data.Maybe
+import Data.Bits
+import Data.Map             (Map)
+import qualified Data.ByteString     as BS
+import qualified Data.Map.Strict     as Map
+import qualified Data.Set            as Set
+import qualified Data.HashMap.Strict as HM
+import GHC.Generics    (Generic)
+
+import HSChain.Types.Blockchain
+import HSChain.Types.Merkle.Types
+import HSChain.Types.Validators
+import HSChain.Crypto
+import HSChain.Crypto.Classes.Hash
+import HSChain.Crypto.Ed25519
+import HSChain.Crypto.SHA
+
+
+----------------------------------------------------------------
+--
+----------------------------------------------------------------
+
+-- | Block data. It's simply newtype wrapper over list of
+--   transactions. Newtype is needed in order to define 'BlockData'
+--   instance.
+newtype BData = BData [Tx]
+  deriving stock    (Show,Eq,Generic)
+  deriving newtype  (NFData,JSON.ToJSON,JSON.FromJSON)
+  deriving anyclass (Serialise)
+instance CryptoHashable BData where
+  hashStep = genericHashStep "hschain-examples"
+
+-- | Error in coin transaction processing
+data CoinError
+  = DepositAtWrongH
+  | UnexpectedSend
+  | CoinError String
+  deriving stock    (Show,Generic)
+  deriving anyclass (Exception,NFData)
+
+instance BlockData BData where
+  type TX              BData = Tx
+  type BlockchainState BData = CoinState
+  type BChError        BData = CoinError
+  type BChMonad        BData = Either CoinError
+  type Alg             BData = Ed25519 :& SHA512
+  bchLogic                 = coinLogic
+  proposerSelection        = ProposerSelection randomProposerSHA512
+  logBlockData (BData txs) = HM.singleton "Ntx" $ JSON.toJSON $ length txs
+
+-- | Single transaction. We have two different transaction one to add
+--   money to account ex nihilo and one to transfer money between
+--   accounts.
+data Tx
+  = Deposit !(PublicKey (Alg BData)) !Integer
+    -- ^ Deposit tokens to given key. Could only appear in genesis
+    --   block (H=0)
+  | Send !(PublicKey (Alg BData)) !(Signature (Alg BData)) !TxSend
+    -- ^ Send coins to other addresses. Transaction must obey
+    --   following invariants:
+    --
+    --   0. Signature must be valid
+    --   1. All inputs must be owned by transaction issuer
+    --   3. Inputs and outputs must be nonempty
+    --   2. Sum of inputs must be equal to sum of outputs
+  deriving stock    (Show, Eq, Ord, Generic)
+  deriving anyclass (Serialise, NFData, JSON.ToJSON, JSON.FromJSON)
+
+-- | Single transaction for transfer of coins.
+data TxSend = TxSend
+  { txInputs  :: [UTXO]         -- ^ List of inputs that are spent in this TX
+  , txOutputs :: [Unspent]      -- ^ List of outputs of this TX
+  }
+  deriving stock    (Show, Eq, Ord, Generic)
+  deriving anyclass (Serialise, NFData, JSON.ToJSON, JSON.FromJSON)
+
+-- | Pair of transaction hash and output number
+data UTXO = UTXO !Int !(Hashed (Alg BData) Tx)
+  deriving stock    (Show, Eq, Ord, Generic)
+  deriving anyclass (Serialise, NFData, JSON.ToJSON, JSON.FromJSON)
+
+-- | Unspent coins belonging to some private key. It's identified by
+--   public key and unspent amount.
+data Unspent = Unspent !(PublicKey (Alg BData)) !Integer
+  deriving stock    (Show, Eq, Ord, Generic)
+  deriving anyclass (Serialise, NFData, JSON.ToJSON, JSON.FromJSON)
+
+-- | State of coins in program-digestible format
+data CoinState = CoinState
+  { unspentOutputs :: !(Map UTXO Unspent)
+    -- ^ Map of unspent outputs of transaction. It maps pair of
+    --   transaction hash and output index to amount of coins stored
+    --   there.
+  , utxoLookup     :: !(Map (PublicKey (Alg BData)) (Set.Set UTXO))
+    -- ^ UTXO set partitioned by corresponding public key. Only needed
+    --   for efficient TX generation
+  }
+  deriving stock    (Show,   Generic)
+  deriving anyclass (NFData, Serialise)
+
+instance CryptoHashable TxSend where
+  hashStep = genericHashStep "hschain"
+instance CryptoHashable Tx where
+  hashStep = genericHashStep "hschain"
+instance CryptoHashable UTXO where
+  hashStep = genericHashStep "hschain"
+instance CryptoHashable Unspent where
+  hashStep = genericHashStep "hschain"
+instance CryptoHashable CoinState where
+  hashStep = genericHashStep "hschain"
+
+
+
+----------------------------------------------------------------
+-- Basic coin logic
+----------------------------------------------------------------
+
+-- | Complete description of blockchain logic. Since we keep all state
+--   in memory we simply use @Maybe@ to track failures
+coinLogic :: BChLogic (Either CoinError) BData
+coinLogic = BChLogic
+  { processTx     = \BChEval{..} -> void $ processTransaction bchValue (merkleValue blockchainState)
+  --
+  , processBlock  = \BChEval{..} -> do
+      let h    = blockHeight bchValue
+          step = flip $ process h
+      st <- foldM step (merkleValue blockchainState)
+          $ let BData txs = merkleValue $ blockData bchValue
+            in txs
+      return BChEval { bchValue        = ()
+                     , blockchainState = merkled st
+                     , ..
+                     }
+  --
+  , generateBlock = \NewBlock{..} txs -> do
+      let selectTx c []     = (c,[])
+          selectTx c (t:tx) = case processTransaction t c of
+                                Left  _  -> selectTx c  tx
+                                Right c' -> let (c'', b  ) = selectTx c' tx
+                                            in  (c'', t:b)
+      let (st', dat) = selectTx (merkleValue newBlockState) txs
+      return BChEval { bchValue        = BData dat
+                     , validatorSet    = merkled newBlockValSet
+                     , blockchainState = merkled st'
+                     }
+  }
+  where
+    process (Height 0) t s = case processDeposit t s of
+      Right x -> Right x
+      Left  _ -> processTransaction t s
+    process _          t s = processTransaction t s
+
+
+-- | Process deposit transaction. Should only be called for
+--   transactions from genesis block
+processDeposit :: Tx -> CoinState -> Either CoinError CoinState
+processDeposit Send{}                _             = Left UnexpectedSend
+processDeposit tx@(Deposit pk nCoin) CoinState{..} =
+  return CoinState
+    { unspentOutputs = Map.insert utxo (Unspent pk nCoin) unspentOutputs
+    , utxoLookup     = Map.alter (\case
+                                     Nothing -> Just (Set.singleton utxo)
+                                     Just s  -> Just (Set.insert utxo s)
+                                 ) pk utxoLookup
+    }
+  where
+    utxo = UTXO 0 (hashed tx)
+
+-- | Process money movement transaction
+processTransaction :: Tx -> CoinState -> Either CoinError CoinState
+processTransaction Deposit{} _ = Left DepositAtWrongH
+processTransaction transaction@(Send pubK sig txSend@TxSend{..}) CoinState{..} = do
+  -- Inputs and outputs are not null
+  when (null txInputs)  $ Left $ CoinError "Empty input  list"
+  when (null txOutputs) $ Left $ CoinError "Empty output list"
+  -- Outputs are all positive
+  forM_ txOutputs $ \(Unspent _ n) ->
+    unless (n > 0) $ Left $ CoinError "Negative output"
+  -- Inputs are owned Spend and generated amount match and transaction
+  -- issuer have rights to funds
+  inputs <- forM txInputs $ \i -> do
+    Unspent pk n <- case Map.lookup i unspentOutputs of
+      Just x  -> return x
+      Nothing -> Left $ CoinError "Unknown input"
+    unless (pk == pubK) $ Left $ CoinError "Mismatch of publick keys"
+    return n
+  unless (sum inputs == sum [n | Unspent _ n <- txOutputs])
+    $ Left $ CoinError "Missmatch between inputs and outputs"
+  -- Signature must be valid. Note signature check is expensive so
+  -- it's done at last moment
+  unless (verifySignatureHashed pubK txSend sig)
+    $ Left $ CoinError "Invalid signature"
+  -- Update application state
+  let txHash  = hashed transaction
+  return CoinState
+    { unspentOutputs =
+        let spend txMap = foldl' (flip  Map.delete) txMap txInputs
+            add   txMap = foldl'
+                            (\m (i,out) -> Map.insert (UTXO i txHash) out m)
+                            txMap ([0..] `zip` txOutputs)
+        in add $ spend unspentOutputs
+    , utxoLookup =
+        let insert m (i,Unspent k _) = Map.alter
+              (\case
+                  Nothing -> Just $ Set.singleton (UTXO i txHash)
+                  Just s  -> Just $ Set.insert    (UTXO i txHash) s
+              ) k m
+            add    utxos = foldl' insert utxos ([0..] `zip` txOutputs)
+            remove utxos = foldl' (flip Set.delete) utxos txInputs
+        in add $ Map.adjust remove pubK utxoLookup
+    }
+
+
+-- | Select proposers using PRNG based on SHA512.
+randomProposerSHA512 :: Crypto alg => ValidatorSet alg -> Height -> Round -> ValidatorIdx alg
+randomProposerSHA512 valSet h r
+  = fromMaybe (error "randomProposerSHA512: invalid index")
+  $ indexByIntervalPoint valSet
+  $ fromInteger
+  -- NOTE: We just compute modulo total voting power. This gives
+  --       _biased_ results. But since range of SHA512 is enormous:
+  --       2^512 even for voting power on order 2^64 bias will be on
+  --       order 10^{-134} that is negligible
+  $ (`mod` fromIntegral (totalVotingPower valSet))
+  -- Convert hash to integer. We interpret hash as LE integer
+  $ BS.foldr' (\w i -> (i `shiftL` 8) + fromIntegral  w) 0 bs
+  where
+    Hash bs = hash (valSet, h, r) :: Hash SHA512

--- a/hschain-examples-types/HSChain/Mock/Dioxane/Types.hs
+++ b/hschain-examples-types/HSChain/Mock/Dioxane/Types.hs
@@ -1,0 +1,205 @@
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+-- |
+module HSChain.Mock.Dioxane.Types where
+
+import Codec.Serialise      (Serialise)
+import Control.Applicative
+import Control.Monad
+import Control.Monad.Catch
+import Control.Parallel.Strategies
+import Data.Int
+import Data.Bits
+import Data.Maybe
+import qualified Data.Aeson          as JSON
+import qualified Data.Map.Strict     as Map
+import qualified Data.Vector         as V
+import qualified Data.HashMap.Strict as HM
+import qualified Data.ByteString     as BS
+import Control.Lens
+import GHC.Generics (Generic)
+
+import HSChain.Crypto
+import HSChain.Crypto.Classes.Hash
+import HSChain.Crypto.Ed25519
+import HSChain.Crypto.SHA
+import HSChain.Types
+import HSChain.Types.Merkle.Types
+
+
+----------------------------------------------------------------
+-- Basic coin logic
+----------------------------------------------------------------
+
+type DioAlg = Ed25519 :& SHA512
+
+newtype BData tag = BData [Tx]
+  deriving stock    (Show,Eq,Generic)
+  deriving newtype  (NFData,JSON.ToJSON,JSON.FromJSON)
+  deriving anyclass (Serialise)
+instance CryptoHashable (BData tag) where
+  hashStep = genericHashStep "hschain-examples"
+
+data Tx = Tx
+  { txSig  :: !(Signature DioAlg)
+  , txBody :: !TxBody
+  }
+  deriving stock    (Show, Eq, Ord, Generic)
+  deriving anyclass (Serialise, NFData, JSON.ToJSON, JSON.FromJSON)
+
+data TxBody = TxBody
+  { txFrom   :: !(PublicKey DioAlg)
+  , txTo     :: !(PublicKey DioAlg)
+  , txNonce  :: !Int64
+  , txAmount :: !Int64
+  }
+  deriving stock    (Show, Eq, Ord, Generic)
+  deriving anyclass (Serialise, NFData, JSON.ToJSON, JSON.FromJSON)
+
+data DioError = DioError
+  deriving stock    (Show,Generic)
+  deriving anyclass (Exception,NFData)
+
+data DioState = DioState
+  { _userMap :: Map.Map (PublicKey DioAlg) UserState
+  }
+  deriving stock    (Show,   Generic)
+  deriving anyclass (NFData, Serialise)
+
+data UserState = UserState
+  { _userNonce   :: !Int64
+  , _userBalance :: !Int64
+  }
+  deriving stock    (Show,   Generic)
+  deriving anyclass (NFData, Serialise)
+
+instance CryptoHashable Tx where
+  hashStep = genericHashStep "hschain.dioxane"
+instance CryptoHashable TxBody where
+  hashStep = genericHashStep "hschain.dioxane"
+instance CryptoHashable DioState where
+  hashStep = genericHashStep "hschain.dioxane"
+instance CryptoHashable UserState where
+  hashStep = genericHashStep "hschain.dioxane"
+
+
+makeLenses ''UserState
+makeLenses ''DioState
+
+instance Dio tag => BlockData (BData tag) where
+  type TX              (BData tag) = Tx
+  type BlockchainState (BData tag) = DioState
+  type BChError        (BData tag) = DioError
+  type BChMonad        (BData tag) = Maybe
+  type Alg             (BData tag) = DioAlg
+  bchLogic                 = dioLogic
+  proposerSelection        = ProposerSelection randomProposerSHA512
+  logBlockData (BData txs) = HM.singleton "Ntx" $ JSON.toJSON $ length txs
+
+
+----------------------------------------------------------------
+-- Logic
+----------------------------------------------------------------
+
+class Dio a where
+  dioDict :: DioDict a
+
+data DioDict a = DioDict
+  { dioUserKeys       :: V.Vector ( PrivKey   DioAlg
+                                  , PublicKey DioAlg
+                                  )
+  , dioInitialBalance :: Int64
+  , dioValidators     :: Int64
+  }
+
+dioLogic :: forall tag. Dio tag => BChLogic Maybe (BData tag)
+dioLogic = BChLogic
+  { processTx     = const empty
+  --
+  , processBlock  = \BChEval{..} -> do
+      let sigCheck = guard
+                   $ and
+                   $ parMap rseq
+                     (\(Tx sig tx) -> verifySignatureHashed (txFrom tx) tx sig)
+                     (let BData txs = merkleValue $ blockData bchValue
+                      in txs
+                     )
+      let update   = foldM (flip process) (merkleValue blockchainState)
+                   $ (let BData txs = merkleValue $ blockData bchValue
+                      in txs
+                     )
+      st <- uncurry (>>)
+          $ withStrategy (evalTuple2 rpar rpar)
+          $ (sigCheck, update)
+      return BChEval { bchValue        = ()
+                     , blockchainState = merkled st
+                     , ..
+                     }
+  -- We generate one transaction for every key. And since we move
+  -- money from one account to another it's quite simple to update state
+  , generateBlock = \NewBlock{..} _ -> do
+      let nonce = let Height h = newBlockHeight in fromIntegral h - 1
+          keys  = dioUserKeys
+      return $! BChEval
+        { bchValue = BData
+                   $ parMap rseq
+                     (\(sk,pk) -> let body = TxBody
+                                        { txTo     = pk
+                                        , txFrom   = pk
+                                        , txNonce  = nonce
+                                        , txAmount = 1
+                                        }
+                                  in Tx { txSig  = signHashed sk body
+                                        , txBody = body
+                                        }
+                     )
+                     (V.toList keys)
+        , validatorSet    = merkled newBlockValSet
+        , blockchainState = merkled
+                          $ userMap . each . userNonce %~ succ
+                          $ merkleValue newBlockState
+        }
+  }
+  where
+    DioDict{..} = dioDict @tag
+
+
+process :: Tx -> DioState -> Maybe DioState
+process Tx{txBody=TxBody{..}} st = do
+  ufrom  <- st ^. userMap . at txFrom
+  _      <- st ^. userMap . at txTo
+  -- Nonce is correct & and we have funds
+  guard $ txNonce == ufrom^.userNonce
+  guard $ ufrom^.userBalance >= txAmount
+  return
+    $! st
+    & userMap . at txFrom . _Just %~ ( (userNonce   %~ succ)
+                                     . (userBalance %~ subtract txAmount)
+                                     )
+    & userMap . at txTo   . _Just . userBalance %~ (+ txAmount)
+
+-- | Select proposers using PRNG based on SHA512.
+randomProposerSHA512 :: Crypto alg => ValidatorSet alg -> Height -> Round -> ValidatorIdx alg
+randomProposerSHA512 valSet h r
+  = fromMaybe (error "randomProposerSHA512: invalid index")
+  $ indexByIntervalPoint valSet
+  $ fromInteger
+  -- NOTE: We just compute modulo total voting power. This gives
+  --       _biased_ results. But since range of SHA512 is enormous:
+  --       2^512 even for voting power on order 2^64 bias will be on
+  --       order 10^{-134} that is negligible
+  $ (`mod` fromIntegral (totalVotingPower valSet))
+  -- Convert hash to integer. We interpret hash as LE integer
+  $ BS.foldr' (\w i -> (i `shiftL` 8) + fromIntegral  w) 0 bs
+  where
+    Hash bs = hash (valSet, h, r) :: Hash SHA512

--- a/hschain-examples-types/LICENSE
+++ b/hschain-examples-types/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2020 BITRU LLC
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/hschain-examples-types/Setup.hs
+++ b/hschain-examples-types/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/hschain-examples-types/hschain-examples-types.cabal
+++ b/hschain-examples-types/hschain-examples-types.cabal
@@ -27,12 +27,9 @@ Library
                      , containers           >=0.5.9
                      , deepseq              >=1.4
                      , lens
-                     , mmorph
                      , exceptions           >=0.8.3
                      , parallel
-                     , random
                      , serialise            >=0.2
-                     , stm                  >=2.5
                      , transformers         >=0.5
                      , unordered-containers >=0.2.5.0
                      , vector

--- a/hschain-examples-types/hschain-examples-types.cabal
+++ b/hschain-examples-types/hschain-examples-types.cabal
@@ -1,0 +1,41 @@
+Name:           hschain-examples-types
+Version:        0.1
+Synopsis:       Types for examples and tests for hschain
+Description:
+  They're placed into separate pacakge to allow compilation with 
+            Implementation of very simple and not quite realistic coin on blockchain
+
+Cabal-Version:  >= 1.10
+License:        MIT
+License-File:   LICENSE
+Author:         Aleksey Khudyakov <alexey.skladnoy@gmail.com>
+Maintainer:     Aleksey Khudyakov <alexey.skladnoy@gmail.com>
+Homepage:       https://github.com/hexresearch/thundermint
+Category:       Data
+Build-Type:     Simple
+
+Library
+  Ghc-options:         -Wall
+  Default-Language:    Haskell2010
+  Build-Depends:       base              >=4.9 && <5
+                     , hschain-crypto
+                     , hschain-types
+                     , hschain-merkle
+                       --
+                     , aeson
+                     , bytestring           >=0.10
+                     , containers           >=0.5.9
+                     , deepseq              >=1.4
+                     , lens
+                     , mmorph
+                     , exceptions           >=0.8.3
+                     , parallel
+                     , random
+                     , serialise            >=0.2
+                     , stm                  >=2.5
+                     , transformers         >=0.5
+                     , unordered-containers >=0.2.5.0
+                     , vector
+  Exposed-modules:
+                  HSChain.Mock.Coin.Types
+                  HSChain.Mock.Dioxane.Types

--- a/hschain-examples/HSChain/Mock/Coin.hs
+++ b/hschain-examples/HSChain/Mock/Coin.hs
@@ -45,18 +45,13 @@ import Control.Monad.Trans.Class
 import Control.Monad.Trans.Cont
 import Control.Monad.Trans.Except
 import Control.Concurrent   (threadDelay)
-import Control.DeepSeq
-import Codec.Serialise      (Serialise)
-import qualified Data.Aeson as JSON
 import Data.Foldable
 import Data.Maybe
-import Data.Map             (Map,(!))
+import Data.Map             ((!))
 import qualified Data.Vector         as V
 import qualified Data.Map.Strict     as Map
 import qualified Data.Set            as Set
-import qualified Data.HashMap.Strict as HM
 import System.Random   (randomRIO)
-import GHC.Generics    (Generic)
 
 import HSChain.Types.Blockchain
 import HSChain.Types.Merkle.Types
@@ -65,208 +60,16 @@ import HSChain.Blockchain.Internal.Engine.Types
 import HSChain.Control
 import HSChain.Control.Class
 import HSChain.Crypto
-import HSChain.Crypto.Classes.Hash
-import HSChain.Crypto.Ed25519
-import HSChain.Crypto.SHA
 import HSChain.Logger
 import HSChain.Run
 import HSChain.Mock
+import HSChain.Mock.Coin.Types
 import HSChain.Store
 import HSChain.Store.STM
 import HSChain.Mock.KeyList         (makePrivKeyStream)
 import HSChain.Mock.Types
 import HSChain.Monitoring
 import qualified HSChain.Network.Mock as P2P
-
-
-----------------------------------------------------------------
--- Basic coin logic
-----------------------------------------------------------------
-
--- | Block data. It's simply newtype wrapper over list of
---   transactions. Newtype is needed in order to define 'BlockData'
---   instance.
-newtype BData = BData [Tx]
-  deriving stock    (Show,Eq,Generic)
-  deriving newtype  (NFData,JSON.ToJSON,JSON.FromJSON)
-  deriving anyclass (Serialise)
-instance CryptoHashable BData where
-  hashStep = genericHashStep "hschain-examples"
-
--- | Error in coin transaction processing
-data CoinError
-  = DepositAtWrongH
-  | UnexpectedSend
-  | CoinError String
-  deriving stock    (Show,Generic)
-  deriving anyclass (Exception,NFData)
-
-instance BlockData BData where
-  type TX              BData = Tx
-  type BlockchainState BData = CoinState
-  type BChError        BData = CoinError
-  type BChMonad        BData = Either CoinError
-  type Alg             BData = Ed25519 :& SHA512
-  bchLogic                 = coinLogic
-  proposerSelection        = ProposerSelection randomProposerSHA512
-  logBlockData (BData txs) = HM.singleton "Ntx" $ JSON.toJSON $ length txs
-
--- | Single transaction. We have two different transaction one to add
---   money to account ex nihilo and one to transfer money between
---   accounts.
-data Tx
-  = Deposit !(PublicKey (Alg BData)) !Integer
-    -- ^ Deposit tokens to given key. Could only appear in genesis
-    --   block (H=0)
-  | Send !(PublicKey (Alg BData)) !(Signature (Alg BData)) !TxSend
-    -- ^ Send coins to other addresses. Transaction must obey
-    --   following invariants:
-    --
-    --   0. Signature must be valid
-    --   1. All inputs must be owned by transaction issuer
-    --   3. Inputs and outputs must be nonempty
-    --   2. Sum of inputs must be equal to sum of outputs
-  deriving stock    (Show, Eq, Ord, Generic)
-  deriving anyclass (Serialise, NFData, JSON.ToJSON, JSON.FromJSON)
-
--- | Single transaction for transfer of coins.
-data TxSend = TxSend
-  { txInputs  :: [UTXO]         -- ^ List of inputs that are spent in this TX
-  , txOutputs :: [Unspent]      -- ^ List of outputs of this TX
-  }
-  deriving stock    (Show, Eq, Ord, Generic)
-  deriving anyclass (Serialise, NFData, JSON.ToJSON, JSON.FromJSON)
-
--- | Pair of transaction hash and output number
-data UTXO = UTXO !Int !(Hashed (Alg BData) Tx)
-  deriving stock    (Show, Eq, Ord, Generic)
-  deriving anyclass (Serialise, NFData, JSON.ToJSON, JSON.FromJSON)
-
--- | Unspent coins belonging to some private key. It's identified by
---   public key and unspent amount.
-data Unspent = Unspent !(PublicKey (Alg BData)) !Integer
-  deriving stock    (Show, Eq, Ord, Generic)
-  deriving anyclass (Serialise, NFData, JSON.ToJSON, JSON.FromJSON)
-
--- | State of coins in program-digestible format
-data CoinState = CoinState
-  { unspentOutputs :: !(Map UTXO Unspent)
-    -- ^ Map of unspent outputs of transaction. It maps pair of
-    --   transaction hash and output index to amount of coins stored
-    --   there.
-  , utxoLookup     :: !(Map (PublicKey (Alg BData)) (Set.Set UTXO))
-    -- ^ UTXO set partitioned by corresponding public key. Only needed
-    --   for efficient TX generation
-  }
-  deriving stock    (Show,   Generic)
-  deriving anyclass (NFData, Serialise)
-
-instance CryptoHashable TxSend where
-  hashStep = genericHashStep "hschain"
-instance CryptoHashable Tx where
-  hashStep = genericHashStep "hschain"
-instance CryptoHashable UTXO where
-  hashStep = genericHashStep "hschain"
-instance CryptoHashable Unspent where
-  hashStep = genericHashStep "hschain"
-instance CryptoHashable CoinState where
-  hashStep = genericHashStep "hschain"
-
-
-
--- | Process deposit transaction. Should only be called for
---   transactions from genesis block
-processDeposit :: Tx -> CoinState -> Either CoinError CoinState
-processDeposit Send{}                _             = Left UnexpectedSend
-processDeposit tx@(Deposit pk nCoin) CoinState{..} =
-  return CoinState
-    { unspentOutputs = Map.insert utxo (Unspent pk nCoin) unspentOutputs
-    , utxoLookup     = Map.alter (\case
-                                     Nothing -> Just (Set.singleton utxo)
-                                     Just s  -> Just (Set.insert utxo s)
-                                 ) pk utxoLookup
-    }
-  where
-    utxo = UTXO 0 (hashed tx)
-
--- | Process money movement transaction
-processTransaction :: Tx -> CoinState -> Either CoinError CoinState
-processTransaction Deposit{} _ = Left DepositAtWrongH
-processTransaction transaction@(Send pubK sig txSend@TxSend{..}) CoinState{..} = do
-  -- Inputs and outputs are not null
-  when (null txInputs)  $ Left $ CoinError "Empty input  list"
-  when (null txOutputs) $ Left $ CoinError "Empty output list"
-  -- Outputs are all positive
-  forM_ txOutputs $ \(Unspent _ n) ->
-    unless (n > 0) $ Left $ CoinError "Negative output"
-  -- Inputs are owned Spend and generated amount match and transaction
-  -- issuer have rights to funds
-  inputs <- forM txInputs $ \i -> do
-    Unspent pk n <- case Map.lookup i unspentOutputs of
-      Just x  -> return x
-      Nothing -> Left $ CoinError "Unknown input"
-    unless (pk == pubK) $ Left $ CoinError "Mismatch of publick keys"
-    return n
-  unless (sum inputs == sum [n | Unspent _ n <- txOutputs])
-    $ Left $ CoinError "Missmatch between inputs and outputs"
-  -- Signature must be valid. Note signature check is expensive so
-  -- it's done at last moment
-  unless (verifySignatureHashed pubK txSend sig)
-    $ Left $ CoinError "Invalid signature"
-  -- Update application state
-  let txHash  = hashed transaction
-  return CoinState
-    { unspentOutputs =
-        let spend txMap = foldl' (flip  Map.delete) txMap txInputs
-            add   txMap = foldl'
-                            (\m (i,out) -> Map.insert (UTXO i txHash) out m)
-                            txMap ([0..] `zip` txOutputs)
-        in add $ spend unspentOutputs
-    , utxoLookup =
-        let insert m (i,Unspent k _) = Map.alter
-              (\case
-                  Nothing -> Just $ Set.singleton (UTXO i txHash)
-                  Just s  -> Just $ Set.insert    (UTXO i txHash) s
-              ) k m
-            add    utxos = foldl' insert utxos ([0..] `zip` txOutputs)
-            remove utxos = foldl' (flip Set.delete) utxos txInputs
-        in add $ Map.adjust remove pubK utxoLookup
-    }
-
--- | Complete description of blockchain logic. Since we keep all state
---   in memory we simply use @Maybe@ to track failures
-coinLogic :: BChLogic (Either CoinError) BData
-coinLogic = BChLogic
-  { processTx     = \BChEval{..} -> void $ processTransaction bchValue (merkleValue blockchainState)
-  --
-  , processBlock  = \BChEval{..} -> do
-      let h    = blockHeight bchValue
-          step = flip $ process h
-      st <- foldM step (merkleValue blockchainState)
-          $ let BData txs = merkleValue $ blockData bchValue
-            in txs
-      return BChEval { bchValue        = ()
-                     , blockchainState = merkled st
-                     , ..
-                     }
-  --
-  , generateBlock = \NewBlock{..} txs -> do
-      let selectTx c []     = (c,[])
-          selectTx c (t:tx) = case processTransaction t c of
-                                Left  _  -> selectTx c  tx
-                                Right c' -> let (c'', b  ) = selectTx c' tx
-                                            in  (c'', t:b)
-      let (st', dat) = selectTx (merkleValue newBlockState) txs
-      return BChEval { bchValue        = BData dat
-                     , validatorSet    = merkled newBlockValSet
-                     , blockchainState = merkled st'
-                     }
-  }
-  where
-    process (Height 0) t s = case processDeposit t s of
-      Right x -> Right x
-      Left  _ -> processTransaction t s
-    process _          t s = processTransaction t s
 
 
 ----------------------------------------------------------------

--- a/hschain-examples/hschain-examples.cabal
+++ b/hschain-examples/hschain-examples.cabal
@@ -23,6 +23,7 @@ Library
                      , hschain-merkle
                      , hschain
                      , hschain-net
+                     , hschain-examples-types
                        --
                      , aeson
                      , bytestring           >=0.10

--- a/hschain-examples/hschain-examples.cabal
+++ b/hschain-examples/hschain-examples.cabal
@@ -1,8 +1,8 @@
 Name:           hschain-examples
 Version:        0.1
-Synopsis:       Haskell reimplementation of tendermint protocol
+Synopsis:       Examples and tests for hschain
 Description:
-  Haskell reimplementation of tendermint protocol
+  Implementation of very simple and not quite realistic coin on blockchain
 
 Cabal-Version:  >= 1.10
 License:        MIT

--- a/nix/overrides.nix
+++ b/nix/overrides.nix
@@ -33,6 +33,9 @@
     scientific            = { check = false; };
     tasty-quickcheck      = { check = false; };
     QuickCheck            = { check = false; };
+    lens                  = { check = false; };
+    comonad               = { check = false; };
+    semigroupoids         = { check = false; };
     # Test have dependency on cryptonite
     Lazy-Pbkdf2           = { check = false; };
   };

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -39,17 +39,18 @@ let
     bls-signatures = callInternal hsPkgs "bls-signatures" ../bls-signatures {} "";
     hschain-crypto = callInternal hsPkgs "hschain" ../hschain-crypto {}
       (if useSodium then "-flibsodium" else "-f-libsodium");
-    hschain-crypto-bls = callInternal hsPkgs "hschain" ../hschain-crypto-bls    {} "";
-    hschain-quickcheck = callInternal hsPkgs "hschain" ../hschain-quickcheck    {} "";
-    hschain-types      = callInternal hsPkgs "hschain" ../hschain-types         {} "";
-    hschain-merkle     = callInternal hsPkgs "hschain" ../hschain-merkle        {} "";
-    hschain-net        = callInternal hsPkgs "hschain" ../hschain-net           {} "";
-    hschain-pow-func   = callInternal hsPkgs "hschain" ../proof-of-work         {} "";
-    hschain-PoW        = callInternal hsPkgs "hschain" ../hschain-PoW           {} "";
-    hschain            = callInternal hsPkgs "hschain" ../hschain               {} "";
-    hschain-examples   = callInternal hsPkgs "hschain" ../hschain-examples      {} "";
-    hschain-control    = callInternal hsPkgs "hschain" ../hschain-control       {} "";
-    serialise-cddl     = callInternal hsPkgs "hschain" ../serialise-cddl        {} "";
+    hschain-crypto-bls     = callInternal hsPkgs "hschain" ../hschain-crypto-bls     {} "";
+    hschain-quickcheck     = callInternal hsPkgs "hschain" ../hschain-quickcheck     {} "";
+    hschain-types          = callInternal hsPkgs "hschain" ../hschain-types          {} "";
+    hschain-merkle         = callInternal hsPkgs "hschain" ../hschain-merkle         {} "";
+    hschain-net            = callInternal hsPkgs "hschain" ../hschain-net            {} "";
+    hschain-pow-func       = callInternal hsPkgs "hschain" ../proof-of-work          {} "";
+    hschain-PoW            = callInternal hsPkgs "hschain" ../hschain-PoW            {} "";
+    hschain                = callInternal hsPkgs "hschain" ../hschain                {} "";
+    hschain-examples       = callInternal hsPkgs "hschain" ../hschain-examples       {} "";
+    hschain-examples-types = callInternal hsPkgs "hschain" ../hschain-examples-types {} "";
+    hschain-control        = callInternal hsPkgs "hschain" ../hschain-control        {} "";
+    serialise-cddl         = callInternal hsPkgs "hschain" ../serialise-cddl         {} "";
   };
   # Build internal package
   callInternal = hask: name: path: args: opts:
@@ -94,12 +95,14 @@ let
       hschain-PoW
       hschain
       hschain-examples
+      hschain-examples-types
     ];
     hschainPkgJs = p: with p; [
       hschain-crypto
       hschain-control
       hschain-types
       hschain-merkle
+      hschain-examples-types
     ];
     in
     {


### PR DESCRIPTION
This is to allow build of -types package with GHCJS. Split is rather awkward since we have to pull blockchain logic along with type declarations