### PR TITLE
Drop experiements with row polymorphism 

### DIFF
--- a/hschain-examples/HSChain/Mock.hs
+++ b/hschain-examples/HSChain/Mock.hs
@@ -48,16 +48,15 @@ allocateMockNetAddrs net topo nodes =
 
 -- | Allocate resources for node
 allocNode
-  :: forall a m x r. ( MonadIO m, MonadMask m, Has x (NodeSpec a))
-  => x                          -- ^ Node parameters
+  :: ( MonadIO m, MonadMask m)
+  => NodeSpec a
   -> ContT r m (Connection 'RW a, LogEnv)
-allocNode x = do
+allocNode spec = do
   liftIO $ createDirectoryIfMissing True $ takeDirectory dbname
   conn   <- ContT $ withDatabase dbname
   logenv <- ContT $ withLogEnv "TM" "DEV" [ makeScribe s | s <- nspecLogFile spec ]
   return (conn,logenv)
   where
-    spec = getT x :: NodeSpec a
     dbname = fromMaybe "" $ nspecDbName spec
 
 -- | Callback which aborts execution when blockchain exceed given

--- a/hschain-examples/HSChain/Mock.hs
+++ b/hschain-examples/HSChain/Mock.hs
@@ -17,7 +17,6 @@ import System.Directory (createDirectoryIfMissing)
 import System.FilePath  (takeDirectory)
 
 import HSChain.Blockchain.Internal.Engine.Types
-import HSChain.Control
 import HSChain.Logger
 import HSChain.Mock.KeyList
 import HSChain.Mock.Types
@@ -48,9 +47,9 @@ allocNetwork
   -> [NodeSpec a]
   -> ContT r m [(NodeSpec a, BlockchainNet, Connection 'RW a, LogEnv)]
 allocNetwork net topo specs
-  = forM networked $ \(net,spec) -> do
+  = forM networked $ \(bnet,spec) -> do
       (conn,logEnv) <- allocNode spec
-      return (spec,net,conn,logEnv)
+      return (spec,bnet,conn,logEnv)
   where
     networked = allocateMockNetAddrs net topo specs
 

--- a/hschain-examples/HSChain/Mock/Coin.hs
+++ b/hschain-examples/HSChain/Mock/Coin.hs
@@ -57,7 +57,6 @@ import HSChain.Types.Blockchain
 import HSChain.Types.Merkle.Types
 import HSChain.Types.Validators
 import HSChain.Blockchain.Internal.Engine.Types
-import HSChain.Control
 import HSChain.Control.Class
 import HSChain.Crypto
 import HSChain.Logger
@@ -219,11 +218,9 @@ executeNodeSpec
 executeNodeSpec NetSpec{..} coin@CoinSpecification{..} = do
   -- Create mock network and allocate DB handles for nodes
   net       <- liftIO P2P.newMockNet
-  resources <- traverse (\x@(_ :*: nspec) -> do { r <- allocNode nspec; return (x,r)})
-             $ allocateMockNetAddrs net netTopology
-             $ netNodeList
+  resources <- allocNetwork net netTopology netNodeList  
   -- Start nodes
-  rnodes    <- lift $ forM resources $ \((bnet :*: spec), (conn, logenv)) -> do
+  rnodes    <- lift $ forM resources $ \(spec, bnet, conn, logenv) -> do
     let run :: DBT 'RW BData (LoggerT m) x -> m x
         run = runLoggerT logenv . runDBT conn
     (rn, acts) <- run $ interpretSpec

--- a/hschain-examples/HSChain/Mock/Coin.hs
+++ b/hschain-examples/HSChain/Mock/Coin.hs
@@ -215,12 +215,13 @@ interpretSpec genesis p cb = do
 
 executeNodeSpec
   :: (MonadIO m, MonadMask m, MonadFork m, MonadTMMonitoring m)
-  => NetSpec (NodeSpec BData) :*: CoinSpecification
+  => NetSpec (NodeSpec BData)
+  -> CoinSpecification
   -> ContT r m [RunningNode m BData]
-executeNodeSpec (NetSpec{..} :*: coin@CoinSpecification{..}) = do
+executeNodeSpec NetSpec{..} coin@CoinSpecification{..} = do
   -- Create mock network and allocate DB handles for nodes
   net       <- liftIO P2P.newMockNet
-  resources <- traverse (\x -> do { r <- allocNode x; return (x,r)})
+  resources <- traverse (\x -> do { r <- allocNode (getT x); return (x,r)})
              $ allocateMockNetAddrs net netTopology
              $ netNodeList
   -- Start nodes

--- a/hschain-examples/HSChain/Mock/Coin.hs
+++ b/hschain-examples/HSChain/Mock/Coin.hs
@@ -219,7 +219,7 @@ executeNodeSpec
 executeNodeSpec NetSpec{..} coin@CoinSpecification{..} = do
   -- Create mock network and allocate DB handles for nodes
   net       <- liftIO P2P.newMockNet
-  resources <- traverse (\x -> do { r <- allocNode (getT x); return (x,r)})
+  resources <- traverse (\x@(_ :*: nspec) -> do { r <- allocNode nspec; return (x,r)})
              $ allocateMockNetAddrs net netTopology
              $ netNodeList
   -- Start nodes

--- a/hschain-examples/HSChain/Mock/KeyVal.hs
+++ b/hschain-examples/HSChain/Mock/KeyVal.hs
@@ -172,7 +172,7 @@ executeSpec
 executeSpec NetSpec{..} = do
   -- Create mock network and allocate DB handles for nodes
   net       <- liftIO P2P.newMockNet
-  resources <- traverse (\x -> do { r <- allocNode (getT x); return (x,r) })
+  resources <- traverse (\x@(_ :*: nspec) -> do { r <- allocNode nspec; return (x,r) })
              $ allocateMockNetAddrs net netTopology
              $ netNodeList
   -- Start nodes
@@ -192,5 +192,5 @@ executeSpec NetSpec{..} = do
   lift   $ catchAbort $ runConcurrently $ snd =<< rnodes
   return $ fst <$> rnodes
   where
-    valSet  = makeValidatorSetFromPriv $ catMaybes [ x ^.. nspecPrivKey | x <- netNodeList ]
+    valSet  = makeValidatorSetFromPriv $ catMaybes [ nspecPrivKey x | x <- netNodeList ]
     genesis = mkGenesisBlock valSet

--- a/hschain-examples/HSChain/Mock/KeyVal.hs
+++ b/hschain-examples/HSChain/Mock/KeyVal.hs
@@ -41,7 +41,6 @@ import GHC.Generics    (Generic)
 import HSChain.Blockchain.Internal.Engine.Types
 import HSChain.Types.Blockchain
 import HSChain.Types.Merkle.Types
-import HSChain.Control
 import HSChain.Control.Class
 import HSChain.Crypto
 import HSChain.Crypto.Classes.Hash
@@ -172,11 +171,9 @@ executeSpec
 executeSpec NetSpec{..} = do
   -- Create mock network and allocate DB handles for nodes
   net       <- liftIO P2P.newMockNet
-  resources <- traverse (\x@(_ :*: nspec) -> do { r <- allocNode nspec; return (x,r) })
-             $ allocateMockNetAddrs net netTopology
-             $ netNodeList
+  resources <- allocNetwork net netTopology netNodeList
   -- Start nodes
-  rnodes    <- lift $ forM resources $ \((bnet :*: nspec), (conn, logenv)) -> do
+  rnodes    <- lift $ forM resources $ \(nspec, bnet, conn, logenv) -> do
     let run :: DBT 'RW BData (LoggerT m) x -> m x
         run = runLoggerT logenv . runDBT conn
     (rn, acts) <- run $ interpretSpec

--- a/hschain-examples/HSChain/Mock/KeyVal.hs
+++ b/hschain-examples/HSChain/Mock/KeyVal.hs
@@ -173,7 +173,7 @@ executeSpec
 executeSpec NetSpec{..} = do
   -- Create mock network and allocate DB handles for nodes
   net       <- liftIO P2P.newMockNet
-  resources <- traverse (\x -> do { r <- allocNode x; return (x,r) })
+  resources <- traverse (\x -> do { r <- allocNode (getT x); return (x,r) })
              $ allocateMockNetAddrs net netTopology
              $ netNodeList
   -- Start nodes

--- a/hschain-examples/exe/coin-node.hs
+++ b/hschain-examples/exe/coin-node.hs
@@ -108,8 +108,11 @@ main = do
     let run = runMonitorT gauges . runLoggerT logenv . runDBT conn
     -- Actually run node
     lift $ run $ do
-      (RunningNode{..},acts) <- interpretSpec genesis
-        (nspec :*: cfg :*: bnet)
+      (RunningNode{..},acts) <- interpretSpec
+        genesis
+        cfg
+        bnet
+        nspec
         (maybe mempty callbackAbortAtH (optMaxH <|> nodeMaxH))
       txGen <- case mtxGen of
         Nothing  -> return []

--- a/hschain-examples/exe/dioxane-node.hs
+++ b/hschain-examples/exe/dioxane-node.hs
@@ -121,9 +121,10 @@ main = do
     (conn, logenv) <- allocNode nspec
     gauges         <- standardMonitoring
     lift $ runMonitorT gauges . runLoggerT logenv . runDBT conn $ do
-      (RunningNode{..},acts) <- interpretSpec @_ @_ @DioTag
-        (nspec :*: cfg :*: bnet)
+      (RunningNode{..},acts) <- interpretSpec @_ @DioTag
         nodeIdx
+        bnet
+        cfg
         (maybe mempty callbackAbortAtH (optMaxH <|> nodeMaxH))
       logOnException $ runConcurrently acts
 

--- a/hschain-examples/test/TM/Integration.hs
+++ b/hschain-examples/test/TM/Integration.hs
@@ -15,7 +15,6 @@ import Control.Monad.IO.Class
 import Data.Foldable    (toList)
 
 import HSChain.Blockchain.Internal.Engine.Types
-import           HSChain.Control
 import           HSChain.Types.Blockchain
 import           HSChain.Store
 import qualified HSChain.Mock.KeyVal as KeyVal
@@ -74,8 +73,8 @@ runKeyVal  = evalContT $ do
 runCoin :: IO ()
 runCoin = evalContT $ do
     rnodes <- Coin.executeNodeSpec
-            $  spec
-           :*: coin { coinGeneratorDelay = Just 200 }
+               spec
+               coin { coinGeneratorDelay = Just 200 }
     -- Check that each blockchain is internally consistent
     checks <- forM rnodes $ \n -> runDBT (Coin.rnodeConn n) checkStorage
     liftIO $ assertEqual "Failed consistency check" [] (concat checks)

--- a/hschain-examples/test/TM/P2P/PEX.hs
+++ b/hschain-examples/test/TM/P2P/PEX.hs
@@ -24,6 +24,7 @@ import Control.Monad.Trans.Reader
 import Control.Exception
 import Data.Aeson (Value(..),Object)
 import Data.Bool
+import Data.Coerce
 import Data.IORef
 import Data.List
 import Data.Maybe
@@ -47,7 +48,6 @@ import HSChain.Mock.Types
 import HSChain.Control.Delay
 import qualified HSChain.Mock.KeyVal as Mock
 import           HSChain.Mock.KeyVal   (BData)
-import HSChain.Control
 import HSChain.Control.Class
 import HSChain.Logger
 import HSChain.Mock.KeyList
@@ -288,19 +288,17 @@ createTestNetworkWithValidatorsSetAndConfig validators cfg netDescr = do
         initDatabase conn
         let run = runIORefLogT ncScribe . runDBT conn
         (_,actions) <- run $ Mock.interpretSpec genesis
-          (   BlockchainNet
-                { bchNetwork      = createMockNode net (intToNetAddr ncFrom)
-                , bchInitialPeers = intToNetAddr <$> ncTo
-                }
-          :*: (NodeSpec
-                { nspecPrivKey     = validatorPK
-                , nspecDbName      = Nothing
-                , nspecLogFile     = []
-                , nspecPersistIval = Nothing
-                } :: NodeSpec BData)
-              -- 
-          :*: (let Configuration{..} = cfg in Configuration{..})
-          )
+          NodeSpec
+            { nspecPrivKey     = validatorPK
+            , nspecDbName      = Nothing
+            , nspecLogFile     = []
+            , nspecPersistIval = Nothing
+            }
+          BlockchainNet
+            { bchNetwork      = createMockNode net (intToNetAddr ncFrom)
+            , bchInitialPeers = intToNetAddr <$> ncTo
+            }
+          (coerce cfg)
           mempty
         return $ run <$> actions
 

--- a/hschain-examples/test/TM/Validators.hs
+++ b/hschain-examples/test/TM/Validators.hs
@@ -280,7 +280,7 @@ prepareResources
 prepareResources NetSpec{..} = do
   -- Create mock network and allocate DB handles for nodes
   net <- liftIO P2P.newMockNet
-  traverse (\x -> do { r <- allocNode (getT x); return (x,r)})
+  traverse (\x@(_ :*: nspec) -> do { r <- allocNode nspec; return (x,r)})
     $ allocateMockNetAddrs net netTopology
     $ netNodeList
 

--- a/hschain-examples/test/TM/Validators.hs
+++ b/hschain-examples/test/TM/Validators.hs
@@ -281,7 +281,7 @@ prepareResources
 prepareResources NetSpec{..} = do
   -- Create mock network and allocate DB handles for nodes
   net <- liftIO P2P.newMockNet
-  traverse (\x -> do { r <- allocNode x; return (x,r)})
+  traverse (\x -> do { r <- allocNode (getT x); return (x,r)})
     $ allocateMockNetAddrs net netTopology
     $ netNodeList
 

--- a/hschain/HSChain/Control.hs
+++ b/hschain/HSChain/Control.hs
@@ -17,11 +17,8 @@ module HSChain.Control (
   , withMVarM
   , modifyMVarM
   , modifyMVarM_
-    -- * throwing on Maybe and Either
     -- * Products with lookup by type
   , (:*:)(..)
-  , Has(..)
-  , (^..)
   ) where
 
 import Control.Concurrent.MVar
@@ -76,29 +73,6 @@ instance (JSON.FromJSON a, JSON.FromJSON b) => JSON.FromJSON (a :*: b) where
     a <- JSON.parseJSON (JSON.Object o)
     b <- JSON.parseJSON (JSON.Object o)
     return (a :*: b)
-
-
--- | Obtain value from product using its type
-class Has a x where
-  getT :: a -> x
-
--- | Lens-like getter
-(^..) :: (Has a x) => a -> (x -> y) -> y
-a ^.. f = f (getT a)
-
-
-class HasCase a x (eq :: Bool) where
-  getCase :: Proxy# eq -> a -> x
-
-instance {-# OVERLAPPABLE #-} (a ~ b) => Has a b where
-  getT = id
-instance HasCase (a :*: b) x (a == x) => Has (a :*: b) x where
-  getT = getCase (proxy# :: Proxy# (a == x))
-
-instance (a ~ x)   => HasCase (a :*: b) x 'True where
-  getCase _ (a :*: _) = a
-instance (Has b x) => HasCase (a :*: b) x 'False where
-  getCase _ (_ :*: b) = getT b
 
 
 iterateM :: (Monad m) => a -> (a -> m a) -> m b

--- a/hschain/HSChain/Control.hs
+++ b/hschain/HSChain/Control.hs
@@ -26,8 +26,6 @@ import Control.Monad
 import Control.Monad.IO.Class
 import qualified Data.Aeson                       as JSON
 import Control.Monad.Catch (MonadMask, mask, onException)
-import Data.Type.Equality
-import GHC.Exts              (Proxy#,proxy#)
 
 
 ----------------------------------------------------------------


### PR DESCRIPTION
Attempt to play with row type emulation in haskell ended up in predicatable failure. When we try to look up value by its type we need to know type exactly but it breaks down when type is polymorphic (`Foo a`) for some a. It required explicit type annotations which make thing quite awkward to use. 

Another reason to abandon `:*:` is new hchain-config. Instances derived using this library interact with instance `:*:` rather poorly