### PR TITLE
Small tweaks for hschain

### DIFF
--- a/hschain-types/HSChain/Types/Blockchain.hs
+++ b/hschain-types/HSChain/Types/Blockchain.hs
@@ -53,7 +53,6 @@ module HSChain.Types.Blockchain (
   , ValidatedBlock
   , EvaluationResult
   , ProposedBlock
-  , TxValidation
     -- ** Logic of blockchain
   , NewBlock(..)
   , BChLogic(..)
@@ -428,10 +427,6 @@ type EvaluationResult a = BChEval a ()
 --   assmebled by consensus engine so we return only block payload.
 type ProposedBlock   a = BChEval a a
 
--- | Transaction which is to be validated against current state of
---   blockchain.
-type TxValidation    a = BChEval a (TX a)
-
 
 
 
@@ -469,7 +464,7 @@ data NewBlock a = NewBlock
 --   blocks and transactions are done in the monad @q@ which is
 --   assumed to provide access to current state of blockchain
 data BChLogic m a = BChLogic
-  { processTx     :: TxValidation a -> m ()
+  { processTx     :: BChEval a (TX a) -> m ()
     -- ^ Process single transactions. Used only for validator of
     --   transactions in mempool.
   , processBlock  :: BlockValidation a -> m (EvaluationResult a)

--- a/hschain-types/HSChain/Types/Validators.hs
+++ b/hschain-types/HSChain/Types/Validators.hs
@@ -16,6 +16,7 @@
 module HSChain.Types.Validators (
     -- * Validators
     Validator(..)
+  , PrivValidator(..)
     -- ** Validator sets
   , ValidatorSet
   , emptyValidatorSet
@@ -76,6 +77,14 @@ deriving instance Ord  (PublicKey alg) => Ord (Validator alg)
 instance NFData (PublicKey alg) => NFData (Validator alg)
 instance CryptoAsymmetric alg => CryptoHashable (Validator alg) where
   hashStep = genericHashStep "hschain"
+
+-- | Private key of validator. It's just newtype wrapper over regular
+--   private key.
+newtype PrivValidator alg = PrivValidator
+  { validatorPrivKey  :: PrivKey alg
+  }
+  deriving newtype (Show, JSON.ToJSON, JSON.FromJSON)
+
 
 -- | Set of all known validators for given height
 data ValidatorSet alg = ValidatorSet

--- a/hschain/HSChain/Blockchain/Internal/Engine/Types.hs
+++ b/hschain/HSChain/Blockchain/Internal/Engine/Types.hs
@@ -185,12 +185,6 @@ instance HoistDict AppCallbacks where
     , appCanCreateBlock = fun . appCanCreateBlock
     }
 
--- | Our own validator
-newtype PrivValidator alg = PrivValidator
-  { validatorPrivKey  :: PrivKey alg
-  }
-  deriving newtype (Show, ToJSON, FromJSON)
-
 -- | Application connection to outer world
 data AppChans a = AppChans
   { appChanRx  :: TBQueue (MessageRx 'Unverified a)

--- a/hschain/HSChain/Blockchain/Internal/Types.hs
+++ b/hschain/HSChain/Blockchain/Internal/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DeriveAnyClass       #-}
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE DerivingStrategies   #-}
 {-# LANGUAGE FlexibleContexts     #-}
@@ -66,10 +67,14 @@ data ProposalState
     -- ^ Proposal is invalid for some reason
   | UnseenProposal
     -- ^ We don't have complete block data for particular block ID yet
-  deriving (Show, Eq, Generic)
-instance Serialise     ProposalState
-instance JSON.ToJSON   ProposalState
-instance JSON.FromJSON ProposalState
+  deriving stock    (Show, Eq, Generic)
+  deriving anyclass (Serialise, JSON.FromJSON, JSON.ToJSON)
+
+instance Katip.ToObject ProposalState where
+  toObject p = HM.singleton "val" (JSON.toJSON p)
+instance Katip.LogItem ProposalState where
+  payloadKeys _ _ = Katip.AllKeys
+
 
 -- | State for tendermint consensus at some particular height.
 data TMState a = TMState
@@ -152,8 +157,3 @@ data Announcement alg
   | AnnLock         !(Maybe Round)
   deriving (Show,Generic)
 instance Serialise (Announcement alg)
-
-instance Katip.ToObject ProposalState where
-  toObject p = HM.singleton "val" (JSON.toJSON p)
-instance Katip.LogItem ProposalState where
-  payloadKeys _ _ = Katip.AllKeys


### PR DESCRIPTION
Notable changes: PrivValidator is moved to hschain-types to validator's public key.
