### PR TITLE
Split working with database into its own package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,6 +10,7 @@ packages:
          hschain-types
          hschain-PoW
          hschain-net
+         hschain-db
          hschain-quickcheck
          hschain-examples
          hschain-examples-types

--- a/hschain-config/HSChain/Config/Internal/Classes.hs
+++ b/hschain-config/HSChain/Config/Internal/Classes.hs
@@ -73,7 +73,7 @@ class GConfig f where
               -> Value
               -> Parser (f p)
 
-instance (Datatype i, GConfig f) => GConfig (M1 D i f) where
+instance (GConfig f) => GConfig (M1 D i f) where
   parseConfig mangler a v = M1 <$> parseConfig mangler (coerce a) v
 
 instance ( GConfigRec f

--- a/hschain-control/HSChain/Control/Class.hs
+++ b/hschain-control/HSChain/Control/Class.hs
@@ -76,7 +76,7 @@ instance MonadFork m => MonadFork (SL.StateT s m) where
 -- | Fork thread. Any exception except `AsyncException` in forked
 --   thread is forwarded to original thread. When parent thread dies
 --   child thread is killed too
-forkLinked :: (MonadIO m, MonadMask m, MonadFork m)
+forkLinked :: (MonadMask m, MonadFork m)
            => m a              -- ^ Action to execute in forked thread
            -> m b              -- ^ What to do while thread executes
            -> m b
@@ -121,12 +121,12 @@ forkLinkedIO action io = do
 
 
 cforkLinked
-  :: (MonadIO m, MonadMask m, MonadFork m)
+  :: (MonadMask m, MonadFork m)
   => m a -> ContT r m ()
 cforkLinked action = ContT $ forkLinked action . ($ ())
 
 cforkLinkedIO
-  :: (MonadIO m, MonadMask m, MonadFork m)
+  :: (MonadMask m, MonadFork m)
   => IO a -> ContT r m ()
 cforkLinkedIO action = ContT $ forkLinkedIO action . ($ ())
 
@@ -137,7 +137,7 @@ cforkLinkedIO action = ContT $ forkLinkedIO action . ($ ())
 --   thread is killed by exceptions it's rethrown. Being killed by
 --   'AsyncException' is considered normal termination.
 runConcurrently
-  :: (MonadIO m, MonadMask m, MonadFork m)
+  :: (MonadMask m, MonadFork m)
   => [m ()]              -- ^ Functions to run
   -> m ()
 runConcurrently []      = return ()

--- a/hschain-control/HSChain/Control/Shepherd.hs
+++ b/hschain-control/HSChain/Control/Shepherd.hs
@@ -55,7 +55,7 @@ withShepherd
 -- | Create new thread which will be terminated when we exit
 --   corresponding 'withShepherd' block
 newSheep
-  :: (MonadFork m, MonadIO m, MonadMask m)
+  :: (MonadFork m, MonadMask m)
   => Shepherd -> m () -> m ()
 newSheep shepherd action = do
   lock <- liftIO newEmptyMVar
@@ -67,7 +67,7 @@ newSheep shepherd action = do
 --   corresponding 'withShepherd' block. Finalizer action will be
 --   called in any case on thread termination
 newSheepFinally
-  :: (MonadFork m, MonadIO m, MonadMask m)
+  :: (MonadFork m, MonadMask m)
   => Shepherd -> m () -> m () -> m ()
 newSheepFinally shepherd action fini = do
   lock <- liftIO newEmptyMVar

--- a/hschain-db/HSChain/Store/Query.hs
+++ b/hschain-db/HSChain/Store/Query.hs
@@ -246,7 +246,7 @@ instance MonadQueryRO (Query rw) where
   --        - Query 'RO -> Query 'RW
   liftQueryRO = coerce
 
-instance MonadQueryRW (Query 'RW) where
+instance rw ~ 'RW => MonadQueryRW (Query rw) where
   -- NOTE: We need coerce to implement both:
   --        - Query 'RO -> Query 'RW
   --        - Query 'RW -> Query 'RW

--- a/hschain-db/HSChain/Store/Query.hs
+++ b/hschain-db/HSChain/Store/Query.hs
@@ -56,6 +56,9 @@ module HSChain.Store.Query (
   , queryROT
   , queryRWT
   , mustQueryRWT
+    -- * Exceptions
+  , Rollback(..)
+  , UnexpectedRollback(..)
     -- * sqlite-simple helpers
   , CBORed(..)
   ) where

--- a/hschain-db/HSChain/Store/Query.hs
+++ b/hschain-db/HSChain/Store/Query.hs
@@ -1,0 +1,516 @@
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DefaultSignatures          #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE FunctionalDependencies     #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+-- |
+-- Wrappers for sqlite-simple that provide thread safety, ability to
+-- implement read\/write access, caching. It's intended to be used as
+-- foundation for implementation of higher level function for working
+-- with database
+module HSChain.Store.Query (
+    -- * Connection
+    Access(..)
+  , Connection(..)
+  , connectionRO
+  , openConnection
+  , closeConnection
+  , withConnection
+    -- * Monadic API
+    -- ** Monad with access to connection
+  , MonadReadDB(..)
+  , MonadDB(..)
+    -- * MonadQuery
+  , MonadQueryRO(..)
+  , MonadQueryRW(..)
+    -- * Query monad
+  , Query(..)
+  , runQueryRO
+  , runQueryRW
+  , queryRO
+  , queryRW
+  , mustQueryRW
+    -- ** Primitive operations
+  , basicLastInsertRowId
+  , basicQuery
+  , basicQuery1
+  , basicQuery_
+  , basicExecute
+  , basicExecute_
+  , rollback
+    -- * Query transformer
+  , QueryT(..)
+  , runQueryROT
+  , runQueryRWT
+  , queryROT
+  , queryRWT
+  , mustQueryRWT
+    -- * sqlite-simple helpers
+  , CBORed(..)
+  ) where
+
+import Codec.Serialise                (Serialise, deserialise, serialise)
+import Control.Monad
+import Control.Monad.Catch
+import qualified Control.Monad.Fail as Fail
+import Control.Monad.IO.Class
+import Control.Monad.Morph            (MFunctor(..))
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.Reader
+import Control.Monad.Trans.Maybe
+import Control.Monad.Trans.State.Strict as SS(StateT(..))
+import Control.Monad.Trans.State.Lazy   as SL(StateT(..))
+import Control.Monad.Trans.Except            (ExceptT(..))
+import Control.Monad.Trans.Identity          (IdentityT(..))
+import Data.Coerce
+import Data.IORef
+import Data.Int
+import qualified Database.SQLite.Simple           as SQL
+import qualified Database.SQLite.Simple.ToField   as SQL
+import qualified Database.SQLite.Simple.FromField as SQL
+import Pipes (Proxy)
+
+import HSChain.Control.Mutex
+import HSChain.Control.Util
+
+
+----------------------------------------------------------------
+-- Connection to SQL database
+----------------------------------------------------------------
+
+-- | Access rights for storage or whether database queries alter
+--   underlying data
+data Access = RO                -- ^ Read-only access
+            | RW                -- ^ Read-write access
+            deriving (Show)
+
+-- | Connection to sqlite database. It's tagged by level of access to
+--   database (read only or read\/write) and parametrized by cache
+data Connection (rw :: Access) = Connection
+  { connMutex    :: !Mutex
+  , connConn     :: !SQL.Connection
+  , connClosed   :: !(IORef Bool)
+  }
+
+-- | Convert read-only or read-write connection to read-only one.
+connectionRO :: Connection rw -> Connection 'RO
+connectionRO = coerce
+
+-- | Open connection to database and set necessary pragmas
+openConnection :: (MonadIO m) => FilePath -> m (Connection rw)
+openConnection db = liftIO $ do
+  connMutex  <- newMutex
+  connConn   <- SQL.open db
+  connClosed <- newIORef False
+  -- SQLite have support for retrying transactions in case database is
+  -- busy. Here we switch it on
+  SQL.execute_ connConn "PRAGMA busy_timeout = 10"
+  return $! Connection{..}
+
+-- | Close connection to database. Note that we can only close
+--   connection if we have read-write acces to it.
+closeConnection :: MonadIO m => Connection 'RW -> m ()
+closeConnection = closeConnection'
+
+-- | Wrapper for @bracket openConnection closeConnection@ which allows
+--   to open read-only connections as well.
+withConnection
+  :: (MonadMask m, MonadIO m)
+  => FilePath -> (Connection rw -> m x) -> m x
+withConnection db = bracket (openConnection db) closeConnection'
+
+closeConnection' :: MonadIO m => Connection rw -> m ()
+closeConnection' Connection{..} = liftIO $ do
+  uninterruptibleMask_ $ do
+    withMutex connMutex $ do
+      writeIORef connClosed True
+      SQL.close  connConn
+
+
+
+----------------------------------------------------------------
+-- Monadic API
+----------------------------------------------------------------
+
+-- | Monad which provides access to read-only connection to
+--   database. That is it provides access to read-only handle to
+--   database. This type class is expected to be more common than
+--   read\/write one since most of the writing is expected to be done
+--   by library.
+--
+--   Default implementation uses lift.
+class Monad m => MonadReadDB m where
+  askConnectionRO :: m (Connection 'RO)
+  --
+  default askConnectionRO :: (m ~ t f, MonadReadDB f, MonadTrans t)
+                          => m (Connection 'RO)
+  askConnectionRO = lift askConnectionRO
+
+-- | Monad which provides access to read-write connection to
+--   database. It's half-internal API since user code shouldn't write
+--   to the database and writing should be handled by library.
+--
+--   Default implementation uses lift.
+class MonadReadDB m => MonadDB m where
+  askConnectionRW :: m (Connection 'RW)
+  --
+  default askConnectionRW :: (m ~ t f, MonadDB f, MonadTrans t)
+                          => m (Connection 'RW)
+  askConnectionRW = lift askConnectionRW
+
+
+-- | Monad which allows to perform read-only queries. API is just thin
+--   wrappers about @sqlite-simple@ functions thus they shouldn't be
+--   used directly. Also note that it doesn't have 'MonadIO' superclass.
+class Monad m => MonadQueryRO m where
+  liftQueryRO :: Query 'RO x -> m x
+  --
+  default liftQueryRO :: (m ~ t f, MonadQueryRO f, MonadTrans t)
+                      => Query 'RO x -> m x
+  liftQueryRO = lift . liftQueryRO
+
+-- | Monad which can perform read-write queries. @basic*RW@ functions
+--   are same as @RO@ variants and intended to be used as
+class (MonadQueryRO m) => MonadQueryRW m where
+  liftQueryRW :: Query rw x -> m x
+  --
+  default liftQueryRW :: (m ~ t f, MonadQueryRW f, MonadTrans t)
+                      => Query rw x -> m x
+  liftQueryRW = lift . liftQueryRW
+
+
+instance MonadReadDB  m => MonadReadDB  (IdentityT m)
+instance MonadDB      m => MonadDB      (IdentityT m)
+instance MonadQueryRO m => MonadQueryRO (IdentityT m)
+instance MonadQueryRW m => MonadQueryRW (IdentityT m)
+
+instance MonadReadDB  m => MonadReadDB  (MaybeT m)
+instance MonadDB      m => MonadDB      (MaybeT m)
+instance MonadQueryRO m => MonadQueryRO (MaybeT m)
+instance MonadQueryRW m => MonadQueryRW (MaybeT m)
+
+instance MonadReadDB  m => MonadReadDB  (ExceptT e m)
+instance MonadDB      m => MonadDB      (ExceptT e m)
+instance MonadQueryRO m => MonadQueryRO (ExceptT e m)
+instance MonadQueryRW m => MonadQueryRW (ExceptT e m)
+
+instance MonadReadDB  m => MonadReadDB  (ReaderT r m)
+instance MonadDB      m => MonadDB      (ReaderT r m)
+instance MonadQueryRO m => MonadQueryRO (ReaderT r m)
+instance MonadQueryRW m => MonadQueryRW (ReaderT r m)
+
+instance MonadReadDB  m => MonadReadDB  (SS.StateT s m)
+instance MonadDB      m => MonadDB      (SS.StateT s m)
+instance MonadQueryRO m => MonadQueryRO (SS.StateT s m)
+instance MonadQueryRW m => MonadQueryRW (SS.StateT s m)
+
+instance MonadReadDB  m => MonadReadDB  (SL.StateT s m)
+instance MonadDB      m => MonadDB      (SL.StateT s m)
+instance MonadQueryRO m => MonadQueryRO (SL.StateT s m)
+instance MonadQueryRW m => MonadQueryRW (SL.StateT s m)
+
+instance MonadReadDB m => MonadReadDB (Proxy x x' y y' m)
+instance MonadDB     m => MonadDB     (Proxy x x' y y' m)
+
+
+
+----------------------------------------------------------------
+-- Query monad
+----------------------------------------------------------------
+
+-- | Query which doesn't allow any other effect except interaction
+--   with database.
+newtype Query rw x = Query { unQuery :: ReaderT (Connection rw) IO x }
+  deriving newtype (Functor, Applicative, MonadThrow)
+
+instance Monad (Query rm) where
+  return = Query . return
+  Query m >>= f = Query $ (\(Query q) -> q) . f =<< m
+#if !MIN_VERSION_base(4,11,0)
+  fail _ = Query $ throwM Rollback
+#endif
+
+instance Fail.MonadFail (Query rw) where
+  fail _ = Query $ throwM Rollback
+
+instance MonadQueryRO (Query rw) where
+  -- NOTE: We need coerce to implement both:
+  --        - Query 'RO -> Query 'RO
+  --        - Query 'RO -> Query 'RW
+  liftQueryRO = coerce
+
+instance MonadQueryRW (Query 'RW) where
+  -- NOTE: We need coerce to implement both:
+  --        - Query 'RO -> Query 'RW
+  --        - Query 'RW -> Query 'RW
+  liftQueryRW = coerce
+
+-- | Run read-only query. Note that read-only couldn't be rolled back
+--   so they always succeed
+runQueryRO
+  :: (MonadIO m)
+  => Connection rw
+  -> Query 'RO a
+  -> m a
+runQueryRO c (Query q) = liftIO $ do
+  r <- runQueryWorker False c $ runReaderT q (connectionRO c)
+  case r of
+    Nothing -> liftIO $ throwM UnexpectedRollback
+    Just a  -> return a
+
+-- | Run read-write query
+runQueryRW
+  :: (MonadIO m)
+  => Connection 'RW
+  -> Query 'RW a
+  -> m (Maybe a)
+runQueryRW c (Query q) = liftIO $ runQueryWorker True c $ runReaderT q c
+
+-- | Run read-only query using Query monad. Note that read-only
+--   couldn't be rolled back so they always succeed.
+queryRO
+  :: (MonadReadDB m, MonadIO m)
+  => Query 'RO a
+  -> m a
+queryRO q = flip runQueryRO q =<< askConnectionRO
+
+-- | Run read-write query using Query monad. Return @Nothing@ is query
+--   was rolled back
+queryRW
+  :: (MonadDB m, MonadIO m)
+  => Query 'RW a
+  -> m (Maybe a)
+queryRW q = flip runQueryRW q =<< askConnectionRW
+
+-- | Run read-write query using Query monad. Throws
+--   'UnexpectedRollback' exception if query is rolled back was rolled
+--   back.
+mustQueryRW
+  :: (MonadDB m, MonadThrow m, MonadIO m)
+  => Query 'RW a
+  -> m a
+mustQueryRW q
+  = throwNothing UnexpectedRollback =<< flip runQueryRW q =<< askConnectionRW
+
+
+
+basicQuery :: (SQL.ToRow p, SQL.FromRow q) => SQL.Query -> p -> Query rw [q]
+basicQuery sql p = Query $ do
+  conn <- asks connConn
+  liftIO $ SQL.query conn sql p
+
+basicQuery_ :: (SQL.FromRow q) => SQL.Query -> Query rw [q]
+basicQuery_ sql = Query $ do
+  conn <- asks connConn
+  liftIO $ SQL.query_ conn sql
+
+
+basicQuery1 :: (SQL.ToRow row, SQL.FromRow a)
+  => SQL.Query             -- ^ SQL query
+  -> row                   -- ^ Query parameters
+  -> Query rw (Maybe a)
+basicQuery1 sql param =
+  basicQuery sql param >>= \case
+    []  -> return Nothing
+    [x] -> return $ Just x
+    _   -> error "Impossible"
+
+basicLastInsertRowId :: Query 'RW Int64
+basicLastInsertRowId = Query $ do
+  conn <- asks connConn
+  liftIO $ SQL.lastInsertRowId conn
+
+
+basicExecute :: (SQL.ToRow p) => SQL.Query -> p -> Query 'RW ()
+basicExecute sql param = Query $ do
+  conn <- asks connConn
+  liftIO $ SQL.execute conn sql param
+
+basicExecute_ :: SQL.Query -> Query 'RW ()
+basicExecute_ sql = Query $ do
+  conn <- asks connConn
+  liftIO $ SQL.execute_ conn sql
+
+-- | Roll back execution of transaction. It's executed as throwing
+--   of exception which is caught in the 'runQueryT'. Thus other
+--   effects in monadic stack may or may not be rolled back as well.
+rollback :: Query 'RW a
+rollback = Query $ throwM Rollback
+
+
+----------------------------------------------------------------
+-- Monad transformer
+----------------------------------------------------------------
+
+-- | Monad transormer for executing queries to the database. By itself
+--   it's just thin wrapper which signifies that every action in the
+--   monad is performed inside transaction.
+--
+--   Note about transaction semantics. Rollback of transaction is
+--   implemented by throwing and catching exception. So depending on
+--   semantics of monadic stack effects may or may not be rolled back
+--   if DB transaction does not succeed. For example changes to
+--   @StateT@ will while @IO@-effects obviously won't. Proceed with
+--   caution.
+newtype QueryT (rw :: Access) m x = QueryT { unQueryT :: m x }
+  deriving newtype ( Functor, Applicative, MonadIO, MonadThrow, MonadCatch, MonadMask)
+
+instance MFunctor (QueryT rw) where
+  hoist f (QueryT m) = QueryT (f m)
+
+instance MonadThrow m => Monad (QueryT rw m) where
+  return         = QueryT . return
+  QueryT m >>= f = QueryT $ unQueryT . f =<< m
+#if !MIN_VERSION_base(4,11,0)
+  fail _         = throwM Rollback
+#endif
+
+instance MonadThrow m => Fail.MonadFail (QueryT rw m) where
+  fail _ = throwM Rollback
+
+-- | Exception thrown in order to roll back transaction
+data Rollback = Rollback
+  deriving (Show,Eq)
+instance Exception Rollback
+
+data UnexpectedRollback = UnexpectedRollback
+  deriving (Show,Eq)
+instance Exception UnexpectedRollback
+
+-- | Trying to access closed database
+data DatabaseIsClosed = DatabaseIsClosed
+  deriving stock    (Show)
+  deriving anyclass (Exception)
+
+
+instance MonadTrans (QueryT rw) where
+  lift = QueryT
+
+instance (MonadIO m, MonadThrow m, MonadReadDB m) => MonadQueryRO (QueryT rw m) where
+  liftQueryRO (Query action) = QueryT $ do
+    -- NOTE: coercion is needed since we need to implement for both
+    --       QueryT 'RO/'RW
+    liftIO . runReaderT action . coerce =<< askConnectionRO
+
+instance (MonadIO m, MonadThrow m, MonadDB m) => MonadQueryRW (QueryT 'RW m) where
+  liftQueryRW (Query action) = QueryT $ do
+    -- NOTE: coercion is needed since we need to implement for both
+    --       Query 'RO/'RW
+    liftIO . runReaderT action . coerce =<< askConnectionRW
+
+-- | Run read-only query. Note that read-only couldn't be rolled back
+--  so they always succeed
+runQueryROT
+  :: (MonadIO m, MonadMask m)
+  => Connection rw
+  -> QueryT 'RO m a -> m a
+runQueryROT c q = do
+  r <- runQueryWorker False c . unQueryT $ q
+  case r of
+    Nothing -> error "Query 'RO couldn't be rolled back"
+    Just a  -> return a
+
+-- | Run read-write query
+runQueryRWT
+  :: (MonadIO m, MonadMask m)
+  => Connection 'RW
+  -> QueryT 'RW m a
+  -> m (Maybe a)
+runQueryRWT c = runQueryWorker True c . unQueryT
+
+-- | Same as 'queryRO' but for 'QueryT'
+queryROT
+  :: (MonadReadDB m, MonadIO m, MonadMask m)
+  => QueryT 'RO m a
+  -> m a
+queryROT q = flip runQueryROT q =<< askConnectionRO
+
+-- | Same as 'queryRW' but for 'QueryT'
+queryRWT
+  :: (MonadDB m, MonadIO m, MonadMask m)
+  => QueryT 'RW m a
+  -> m (Maybe a)
+queryRWT q = flip runQueryRWT q =<< askConnectionRW
+
+-- | Same as 'mustQueryRW' but for 'QueryT'
+mustQueryRWT
+  :: (MonadDB m, MonadIO m, MonadMask m)
+  => QueryT 'RW m a
+  -> m a
+mustQueryRWT q = throwNothing UnexpectedRollback =<< flip runQueryRWT q =<< askConnectionRW
+
+
+
+
+----------------------------------------------------------------
+-- Running queries
+----------------------------------------------------------------
+
+runQueryWorker
+  :: (MonadIO m, MonadMask m)
+  => Bool
+  -> Connection rw
+  -> m x -> m (Maybe x)
+runQueryWorker isWrite connection sql = withMutex mutex $ do
+  closed <- liftIO $ readIORef $ connClosed connection
+  when closed $ throwM DatabaseIsClosed
+  uninterruptibleMask $ \restore -> do
+    -- This function is rather tricky to get right. We need to maintain
+    -- following invariant: No matter what happens we MUST call either
+    -- ROLLBACK or COMMIT after BEGIN TRANSACTION. Otherwise database
+    -- will be left inside a transaction and any attempt to start
+    -- another will be met with error about nested transactions.
+    --
+    -- It seems that functions from sqlite-simple are interruptible so
+    -- we need to use uninterruptibleMask
+    --
+    --  * BEGIN TRANSACTION does not acquire lock. It's deferred and
+    --    lock is acquired only when database is actually accessed. So
+    --    it's fast
+    --
+    --  * Neither ROLLBACK nor COMMIT should block but may take time for
+    --    IO operations but that's inevitable
+    --
+    -- Therefore usage of uninterruptibleMask is justified
+    --
+    -- See following links for details
+    --  + https://www.sqlite.org/lang_transaction.html
+    --  + https://www.sqlite.org/lockingv3.html
+    liftIO $ SQL.execute_ conn $
+      if isWrite then "BEGIN TRANSACTION IMMEDIATE" else "BEGIN TRANSACTION"
+    r <- try $ restore sql `onError` rollbackTx
+    case r of Left  Rollback -> return Nothing
+              Right x        -> do commitTx
+                                   return $ Just x
+  where
+    rollbackTx = liftIO $ SQL.execute_ conn "ROLLBACK"
+    commitTx   = liftIO $ SQL.execute_ conn "COMMIT"
+    mutex      = connMutex connection
+    conn       = connConn  connection
+
+
+----------------------------------------------------------------
+-- Newtypes
+----------------------------------------------------------------
+
+-- | Newtype wrapper which provides CBOR-encoded To\/FromField
+--   instance for values
+newtype CBORed a = CBORed { unCBORed :: a }
+  deriving Show
+
+instance (Serialise a) => SQL.FromField (CBORed a) where
+  fromField f = CBORed . deserialise <$> SQL.fromField f
+
+instance (Serialise a) => SQL.ToField (CBORed a) where
+  toField (CBORed a) = SQL.toField (serialise a)

--- a/hschain-db/LICENSE
+++ b/hschain-db/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2020 BITRU LLC
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/hschain-db/Setup.hs
+++ b/hschain-db/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/hschain-db/hschain-db.cabal
+++ b/hschain-db/hschain-db.cabal
@@ -1,0 +1,30 @@
+Name:           hschain-db
+Version:        0.1
+Synopsis:       Wrappers for SQLite for hschain
+Description:
+  Wrappers for SQLite for hschain
+
+
+Cabal-Version:  >= 1.10
+License:        MIT
+License-File:   LICENSE
+Author:         Aleksey Khudyakov <alexey.skladnoy@gmail.com>
+Maintainer:     Aleksey Khudyakov <alexey.skladnoy@gmail.com>
+Homepage:       https://github.com/hexresearch/thundermint
+Category:       Data
+Build-Type:     Simple
+
+
+Library
+  Ghc-options:         -Wall
+  Default-Language:    Haskell2010
+  Build-Depends:       base              >=4.9 && <5
+                     , hschain-control
+                     , exceptions        >=0.8.3
+                     , mmorph
+                     , pipes             >=4
+                     , serialise         >=0.2
+                     , sqlite-simple
+                     , transformers      >=0.5
+  Exposed-modules:
+                HSChain.Store.Query

--- a/hschain-examples/HSChain/Mock.hs
+++ b/hschain-examples/HSChain/Mock.hs
@@ -29,7 +29,7 @@ import qualified HSChain.Network.Mock as P2P
 allocNode
   :: ( MonadIO m, MonadMask m)
   => NodeSpec a
-  -> ContT r m (Connection 'RW a, LogEnv)
+  -> ContT r m (Connection 'RW, LogEnv)
 allocNode spec = do
   liftIO $ createDirectoryIfMissing True $ takeDirectory dbname
   conn   <- ContT $ withDatabase dbname
@@ -39,11 +39,11 @@ allocNode spec = do
     dbname = fromMaybe "" $ nspecDbName spec
 
 allocNetwork
-  :: ( MonadIO m, MonadMask m)
+  :: (MonadIO m, MonadMask m)
   => P2P.MockNet
   -> Topology
   -> [NodeSpec a]
-  -> ContT r m [(NodeSpec a, BlockchainNet, Connection 'RW a, LogEnv)]
+  -> ContT r m [(NodeSpec a, BlockchainNet, Connection 'RW, LogEnv)]
 allocNetwork net topo specs
   = forM networked $ \(bnet,spec) -> do
       (conn,logEnv) <- allocNode spec

--- a/hschain-examples/HSChain/Mock/Dioxane.hs
+++ b/hschain-examples/HSChain/Mock/Dioxane.hs
@@ -133,7 +133,7 @@ process Tx{txBody=TxBody{..}} st = do
 
 interpretSpec
   :: forall m tag.
-     ( MonadDB (BData tag) m, MonadFork m, MonadMask m, MonadLogger m
+     ( MonadDB m, MonadCached (BData tag) m, MonadFork m, MonadMask m, MonadLogger m
      , MonadTMMonitoring m, Dio tag
      )
   => Int

--- a/hschain-examples/exe/coin-node.hs
+++ b/hschain-examples/exe/coin-node.hs
@@ -31,7 +31,7 @@ import HSChain.Logger
 import HSChain.Mock.Coin
 import HSChain.Mock.Types
 import HSChain.Run
-
+import HSChain.Store
 import HSChain.Control.Class
 import HSChain.Monitoring
 import HSChain.Mock
@@ -74,6 +74,7 @@ main = do
                                  , bchInitialPeers = realnetSeeds snodeNet
                                  }
     -- Dictionatry with paremeters
+    dictCached <- newCached
     let dict = CoinDictM { dictNamespace = mempty
                          , ..
                          }

--- a/hschain-examples/exe/dioxane-node.hs
+++ b/hschain-examples/exe/dioxane-node.hs
@@ -72,26 +72,28 @@ data AppDict = AppDict
   { dictGauges    :: !PrometheusGauges
   , dictNamespace :: !Namespace
   , dictLogEnv    :: !LogEnv
-  , dictConn      :: !(Connection 'RW (BData DioTag))
+  , dictConn      :: !(Connection 'RW)
+  , dictCached    :: !(Cached (BData DioTag))
   }
   deriving stock (Generic)
 
-newtype AppT m a = AppT { unAppT :: ReaderT AppDict m a }
+newtype AppT m a = AppT { _unAppT :: ReaderT AppDict m a }
   deriving newtype (Functor,Applicative,Monad,MonadIO)
   deriving newtype (MonadThrow,MonadCatch,MonadMask,MonadFork)
-  deriving MonadLogger         via LoggerByTypes    (ReaderT AppDict m)
-  deriving MonadTMMonitoring   via MonitoringByType (ReaderT AppDict m)
-  deriving (MonadReadDB (BData DioTag), MonadDB (BData DioTag))
-       via DatabaseByType (BData DioTag) (ReaderT AppDict m)
+  deriving MonadLogger                  via LoggerByTypes    (ReaderT AppDict m)
+  deriving MonadTMMonitoring            via MonitoringByType (ReaderT AppDict m)
+  deriving (MonadReadDB, MonadDB)       via DatabaseByType   (ReaderT AppDict m)
+  deriving (MonadCached (BData DioTag)) via CachedByType (BData DioTag) (ReaderT AppDict m)
 
-runAppT :: LogEnv -> PrometheusGauges -> Connection 'RW (BData DioTag) -> AppT m a -> m a
-runAppT lenv g conn
-  = flip runReaderT AppDict { dictGauges    = g
-                            , dictNamespace = mempty
-                            , dictLogEnv    = lenv
-                            , dictConn      = conn
-                            }
-  . unAppT
+runAppT :: MonadIO m => LogEnv -> PrometheusGauges -> Connection 'RW -> AppT m a -> m a
+runAppT lenv g conn (AppT act) = do
+  cached <- newCached
+  runReaderT act AppDict { dictGauges    = g
+                         , dictNamespace = mempty
+                         , dictLogEnv    = lenv
+                         , dictConn      = conn
+                         , dictCached    = cached
+                         }
 
 
 data Opts = Opts

--- a/hschain-examples/test/TM/Consensus.hs
+++ b/hschain-examples/test/TM/Consensus.hs
@@ -397,7 +397,7 @@ evidenceIsRecordedProp = withEnvironment $ do
     otherK = take 2 $ filter (/=proposerH2R0) privK
 
 selectAllEvidence
-  :: MonadQueryRO a m
+  :: MonadQueryRO m
   => m [(CBORed (ByzantineEvidence BData), Bool)]
 selectAllEvidence
   = basicQuery_ "SELECT evidence,recorded FROM thm_evidence"
@@ -534,6 +534,7 @@ startConsensus
                 , ConsensusM ()
                 )
 startConsensus k = do
+  initDatabase
   chans <- newAppChans cfg
   ch    <- atomicallyIO $ dupTChan $ appChanTx chans
   st    <- initializeBlockchain genesis

--- a/hschain-examples/test/TM/P2P/Gossip.hs
+++ b/hschain-examples/test/TM/P2P/Gossip.hs
@@ -227,6 +227,7 @@ type TestM   a = StateT  (P2P.State a)
 withGossip :: Int -> TestM Mock.BData x -> IO x
 withGossip n action = do
   withDatabase "" $ \conn -> runHSChainT conn $ do
+    initDatabase
     mustQueryRW $ storeGenesis genesis
     consensusState <- liftIO $ newTVarIO Nothing
     let config = P2P.Config (readTVar consensusState)

--- a/hschain-merkle/HSChain/Types/Merkle/Tree.hs
+++ b/hschain-merkle/HSChain/Types/Merkle/Tree.hs
@@ -44,7 +44,7 @@ newtype MerkleBlockTree f alg a = MerkleBlockTree
   }
   deriving (Show, Foldable, Generic)
 
-merkleBlockTreeHash :: (IsMerkle f) => MerkleBlockTree f alg a -> Hash alg
+merkleBlockTreeHash :: MerkleBlockTree f alg a -> Hash alg
 merkleBlockTreeHash = merkleHash . merkleBlockTree
 
 -- | Single node of tree
@@ -55,10 +55,10 @@ data Node f alg a
   deriving (Show, Foldable, Generic)
 
 
-instance (IsMerkle f, CryptoHash alg) => CryptoHashable (MerkleBlockTree f alg a) where
+instance (CryptoHash alg) => CryptoHashable (MerkleBlockTree f alg a) where
   hashStep = hashStep . merkleBlockTree
 
-instance (IsMerkle f, CryptoHash alg, CryptoHashable a) => CryptoHashable (Node f alg a) where
+instance (CryptoHash alg, CryptoHashable a) => CryptoHashable (Node f alg a) where
   hashStep node
     = hashStep (UserType "hschain" "Merkle.Tree.Node")
    <> case node of

--- a/hschain-merkle/HSChain/Types/Merkle/Types.hs
+++ b/hschain-merkle/HSChain/Types/Merkle/Types.hs
@@ -110,7 +110,7 @@ instance (Show1 f, Show a) => Show (MerkleNode f alg a) where
 instance (NFData a, NFData1 f) => NFData (MerkleNode f alg a) where
   rnf (MNode h f) = rnf h `seq` liftRnf rnf f
 
-instance (CryptoHash alg, IsMerkle f) => CryptoHashable (MerkleNode f alg a) where  
+instance (CryptoHash alg) => CryptoHashable (MerkleNode f alg a) where  
   hashStep = hashStep . merkleHash
 
 

--- a/hschain-types/HSChain/Types/Blockchain.hs
+++ b/hschain-types/HSChain/Types/Blockchain.hs
@@ -174,10 +174,10 @@ data GBlock f a = Block
     --   rely on callback to do anything to it.
   }
   deriving stock    (Generic)
-instance (IsMerkle f, CryptoHash (Alg a)) => CryptoHashable (GBlock f a) where
+instance (CryptoHash (Alg a)) => CryptoHashable (GBlock f a) where
   hashStep = genericHashStep "hschain"
 
-toHeader :: IsMerkle f => GBlock f a-> Header a
+toHeader :: GBlock f a-> Header a
 toHeader Block{..} = Block
   { blockData       = toHashedNode     blockData
   , blockPrevCommit = toHashedNode <$> blockPrevCommit

--- a/hschain/HSChain/Blockchain/Internal/Engine.hs
+++ b/hschain/HSChain/Blockchain/Internal/Engine.hs
@@ -136,7 +136,7 @@ runApplication
      , MonadMask m
      , MonadLogger m
      , MonadTMMonitoring m
-     , BlockData a, Eq a, Show a)
+     , BlockData a)
   => ConsensusCfg app
      -- ^ Configuration
   -> Maybe (PrivValidator (Alg a)) -- ^ Private key of validator

--- a/hschain/HSChain/Internal/Types/Config.hs
+++ b/hschain/HSChain/Internal/Types/Config.hs
@@ -97,10 +97,8 @@ deriving via WithDefault (SnakeCase (DropSmart (Config (Configuration app))))
 
 deriving via WithDefault (SnakeCase (Config (NetworkCfg app)))
   instance ( Default (NetworkCfg app)
-           , Typeable app
            ) => FromJSON (NetworkCfg app)
 
 deriving via WithDefault (SnakeCase (Config (ConsensusCfg app)))
   instance ( Default (ConsensusCfg app)
-           , Typeable app
            ) => FromJSON (ConsensusCfg app)

--- a/hschain/HSChain/P2P.hs
+++ b/hschain/HSChain/P2P.hs
@@ -45,7 +45,7 @@ import HSChain.Types.Blockchain
 --   from remote nodes, initiating connections to them, tracking state
 --   of nodes and gossip.
 startPeerDispatcher
-  :: ( MonadMask m, MonadFork m, MonadLogger m, MonadReadDB a m, MonadTMMonitoring m
+  :: ( MonadMask m, MonadFork m, MonadLogger m, MonadReadDB m, MonadCached a m, MonadTMMonitoring m
      , BlockData a)
   => NetworkCfg app
   -> NetworkAPI               -- ^ API for networking

--- a/hschain/HSChain/P2P/PeerState/Handle/Current.hs
+++ b/hschain/HSChain/P2P/PeerState/Handle/Current.hs
@@ -52,7 +52,7 @@ handler = HandlerDict
 
 
 handlerGossip
-  :: (MonadIO m, MonadReadDB a m, BlockData a)
+  :: (MonadIO m, MonadReadDB m, MonadCached a m, BlockData a)
   => Config n a -> GossipMsg a -> TransitionT CurrentState a m ()
 handlerGossip cfg = \case
   GossipPreVote v@(signedValue -> Vote{..}) -> do
@@ -148,7 +148,7 @@ advanceOurHeightWrk (FullStep ourH _ _) = setFinalState advance
 ----------------------------------------------------------------
 
 handlerProposalTimeoutMsg
-  :: (MonadIO m, MonadReadDB a m)
+  :: (MonadIO m, MonadReadDB m, MonadCached a m)
   => Config n a -> CurrentState a -> m [GossipMsg a]
 handlerProposalTimeoutMsg cfg st = do
   bchH <- queryRO blockchainHeight
@@ -166,7 +166,7 @@ handlerProposalTimeoutMsg cfg st = do
     noRoundInProposals = Set.notMember r $ st ^. peerProposals
 
 handlerPrevoteTimeoutMsg
-  :: (MonadIO m, MonadReadDB a m)
+  :: (MonadIO m, MonadReadDB m, MonadCached a m)
   => Config n a -> CurrentState a -> m [GossipMsg a]
 handlerPrevoteTimeoutMsg cfg st
   | Just polR <- st^.peerLock = gossipPrevotes cfg st polR
@@ -175,7 +175,7 @@ handlerPrevoteTimeoutMsg cfg st
     FullStep _ r _ = st ^. peerStep
 
 gossipPrevotes
-  :: (MonadIO m, MonadReadDB a m)
+  :: (MonadIO m, MonadReadDB m, MonadCached a m)
   => Config n a -> CurrentState a -> Round -> m [GossipMsg a]
 gossipPrevotes cfg st r = do
   bchH <- queryRO blockchainHeight
@@ -200,7 +200,7 @@ gossipPrevotes cfg st r = do
   
 
 handlerPrecommitsTimeoutMsg
-  :: (MonadIO m, MonadReadDB a m)
+  :: (MonadIO m, MonadReadDB m, MonadCached a m)
   => Config n a -> CurrentState a -> m [GossipMsg a]
 handlerPrecommitsTimeoutMsg cfg st = do
   bchH <- queryRO blockchainHeight
@@ -225,7 +225,7 @@ handlerPrecommitsTimeoutMsg cfg st = do
 
 
 handlerBlocksTimeoutMsg
-  :: (MonadIO m, MonadReadDB a m)
+  :: (MonadIO m, MonadReadDB m, MonadCached a m)
   => Config n a -> CurrentState a -> m [GossipMsg a]
 handlerBlocksTimeoutMsg cfg st = do
   bchH <- queryRO blockchainHeight

--- a/hschain/HSChain/P2P/PeerState/Handle/Lagging.hs
+++ b/hschain/HSChain/P2P/PeerState/Handle/Lagging.hs
@@ -97,7 +97,7 @@ addBlock b = do
 ----------------------------------------------------------------
 
 handlerVotesTimeoutMsg
-  :: (MonadIO m, MonadReadDB a m, BlockData a)
+  :: (MonadIO m, MonadReadDB a m)
   => LaggingState a -> m [GossipMsg a]
 handlerVotesTimeoutMsg st = do
   queryRO (retrieveLocalCommit peerH) >>= \case

--- a/hschain/HSChain/P2P/PeerState/Handle/Lagging.hs
+++ b/hschain/HSChain/P2P/PeerState/Handle/Lagging.hs
@@ -42,7 +42,7 @@ handler = HandlerDict
   }
 
 handlerGossip
-  :: (MonadIO m, MonadReadDB a m, BlockData a)
+  :: (MonadIO m, MonadReadDB m, MonadCached a m, BlockData a)
   => GossipMsg a -> TransitionT LaggingState a m ()
 handlerGossip = \case
   GossipPreVote   _ ->
@@ -97,7 +97,7 @@ addBlock b = do
 ----------------------------------------------------------------
 
 handlerVotesTimeoutMsg
-  :: (MonadIO m, MonadReadDB a m)
+  :: (MonadIO m, MonadReadDB m, MonadCached a m)
   => LaggingState a -> m [GossipMsg a]
 handlerVotesTimeoutMsg st = do
   queryRO (retrieveLocalCommit peerH) >>= \case
@@ -123,7 +123,7 @@ handlerVotesTimeoutMsg st = do
 ----------------------------------------------------------------
 
 handlerBlocksTimeoutMsg
-  :: (MonadIO m, MonadReadDB a m, BlockData a)
+  :: (MonadIO m, MonadReadDB m, MonadCached a m, BlockData a)
   => LaggingState a -> m [GossipMsg a]
 handlerBlocksTimeoutMsg st
   | st ^. lagPeerHasProposal

--- a/hschain/HSChain/P2P/PeerState/Handle/Utils.hs
+++ b/hschain/HSChain/P2P/PeerState/Handle/Utils.hs
@@ -23,7 +23,7 @@ import HSChain.P2P.PeerState.Monad
 import HSChain.P2P.PeerState.Types
 
 -- | Unconditionally generate fresh state for peer. Shoudl only be called when we 
-advancePeer :: (Crypto (Alg a), Monad m, MonadIO m, MonadReadDB a m)
+advancePeer :: (Crypto (Alg a), Monad m, MonadIO m, MonadReadDB m, MonadCached a m)
             => FullStep -> TransitionT s a m ()
 advancePeer step@(FullStep h _ _) = setFinalState $ \_ -> do
   ourH <- succ <$> queryRO blockchainHeight

--- a/hschain/HSChain/P2P/PeerState/Monad.hs
+++ b/hschain/HSChain/P2P/PeerState/Monad.hs
@@ -21,7 +21,7 @@ import Control.Monad.State.Strict (StateT(..),execStateT,MonadState(..),modify')
 import HSChain.Crypto
 import HSChain.Types
 import HSChain.Logger
-import HSChain.Store.Internal.Query      (MonadReadDB(..))
+import HSChain.Store.Internal.Query      (MonadCached(..), MonadReadDB(..))
 
 import HSChain.P2P.PeerState.Types
 
@@ -40,7 +40,7 @@ newtype TransitionT s a m r = TransitionT
            , MonadIO
            , MonadThrow
            )
-instance MonadReadDB a m => MonadReadDB a (TransitionT s a m) where
+instance MonadReadDB m => MonadReadDB (TransitionT s a m) where
   askConnectionRO = TransitionT $ lift askConnectionRO
 
 instance Monad m => MonadState (s a) (TransitionT s a m) where
@@ -69,6 +69,7 @@ runTransitionT action st = do
 type HandlerCtx a m = ( Serialise a
                       , Crypto (Alg a)
                       , MonadIO m
-                      , MonadReadDB a m
+                      , MonadReadDB m
+                      , MonadCached a m
                       , MonadLogger m
                       )

--- a/hschain/HSChain/Run.hs
+++ b/hschain/HSChain/Run.hs
@@ -75,7 +75,7 @@ data BlockchainNet = BlockchainNet
 --   'runConcurrently'. List of actions is returned in case when we
 --   need to run something else along them.
 runNode
-  :: ( MonadDB a m, MonadMask m, MonadFork m, MonadLogger m, MonadTMMonitoring m
+  :: ( MonadDB m, MonadCached a m, MonadMask m, MonadFork m, MonadLogger m, MonadTMMonitoring m
      , BlockData a, Eq a, Show a
      )
   => Configuration app         -- ^ Timeouts for network and consensus
@@ -84,6 +84,7 @@ runNode
 runNode Configuration{..} NodeDescription{..} = do
   let BlockchainNet{..}  = nodeNetwork
   appCh <- newAppChans cfgConsensus
+  initDatabase
   st    <- initializeBlockchain nodeGenesis nodeStateView
   return
     [ id $ descendNamespace "net"

--- a/hschain/HSChain/Store.hs
+++ b/hschain/HSChain/Store.hs
@@ -30,6 +30,7 @@ module HSChain.Store (
   , connectionRO
   , MonadReadDB(..)
   , MonadDB(..)
+  , MonadCached(..)
   , queryRO
   , queryRW
   , mustQueryRW
@@ -44,10 +45,14 @@ module HSChain.Store (
   , MonadQueryRO(..)
   , MonadQueryRW(..)
   , Query
+  , Cached
+  , newCached
     -- ** Standard DB wrapper
   , DatabaseByField(..)
   , DatabaseByType(..)
   , DatabaseByReader(..)
+  , CachedByField(..)
+  , CachedByType(..)
     -- ** Standard API
   , blockchainHeight
   , retrieveBlock
@@ -100,22 +105,12 @@ import HSChain.Types.Validators
 withDatabase
   :: (MonadIO m, MonadMask m)
   => FilePath         -- ^ Path to the database
-  -> (Connection 'RW a -> m x) -> m x
-withDatabase path cont
-  = withConnection path $ \c -> initDatabase c >> cont c
+  -> (Connection 'RW -> m x) -> m x
+withDatabase = withConnection
 
 -- | Initialize all required tables in database.
-initDatabase
-  :: (MonadIO m)
-  => Connection 'RW a  -- ^ Opened connection to database
-  -> m ()
-initDatabase c = do
-  r <- runQueryRW c initializeBlockhainTables
-  case r of
-    Nothing -> error "Cannot initialize tables!"
-    Just () -> return ()
-
-
+initDatabase :: (MonadIO m, MonadDB m, MonadCached a m) => m ()
+initDatabase = mustQueryRW initializeBlockhainTables
 
 
 ----------------------------------------------------------------
@@ -168,7 +163,7 @@ data BlockchainInconsistency
 
 -- | check storage against all consistency invariants
 checkStorage
-  :: (MonadReadDB a m, MonadIO m, Crypto (Alg a), Serialise a, CryptoHashable a)
+  :: forall m a. (MonadReadDB m, MonadCached a m, MonadIO m, Crypto (Alg a), Serialise a, CryptoHashable a)
   => m [BlockchainInconsistency]
 checkStorage = queryRO $ execWriterT $ do
   maxH         <- lift $ blockchainHeight
@@ -196,7 +191,7 @@ checkStorage = queryRO $ execWriterT $ do
 -- | Check that block proposed at given height is correct in sense all
 --   blockchain invariants hold
 checkProposedBlock
-  :: (MonadReadDB a m, MonadIO m, Crypto (Alg a))
+  :: (MonadReadDB m, MonadCached a m, MonadIO m, Crypto (Alg a))
   => Height
   -> Block a
   -> m [BlockchainInconsistency]
@@ -338,20 +333,18 @@ orElse False e = tell [e]
 -- | Newtype wrapper which allows to derive 'MonadReadDB' and
 --   'MonadDB' instances using deriving via mechanism by specifying name
 --   of field in record carried by reader.
-newtype DatabaseByField conn a m x = DatabaseByField (m x)
+newtype DatabaseByField conn m x = DatabaseByField (m x)
   deriving newtype (Functor,Applicative,Monad)
 
 instance ( MonadReader r m
-         , HasField' conn r (Connection 'RW a)
-         , a ~ a'
-         ) => MonadReadDB a' (DatabaseByField conn a m) where
+         , HasField' conn r (Connection 'RW)
+         ) => MonadReadDB (DatabaseByField conn m) where
   askConnectionRO = DatabaseByField $ connectionRO <$> asks (^. field' @conn)
   {-# INLINE askConnectionRO #-}
 
 instance ( MonadReader r m
-         , HasField' conn r (Connection 'RW a)
-         , a ~ a'
-         ) => MonadDB a' (DatabaseByField conn a m) where
+         , HasField' conn r (Connection 'RW)
+         ) => MonadDB (DatabaseByField conn m) where
   askConnectionRW = DatabaseByField $ asks (^. field' @conn)
   {-# INLINE askConnectionRW #-}
 
@@ -360,20 +353,18 @@ instance ( MonadReader r m
 -- | Newtype wrapper which allows to derive 'MonadReadDB' and
 --   'MonadDB' instances using deriving via mechanism by using type of
 --   field in record carried by reader.
-newtype DatabaseByType a m x = DatabaseByType (m x)
+newtype DatabaseByType m x = DatabaseByType (m x)
   deriving newtype (Functor,Applicative,Monad)
 
 instance ( MonadReader r m
-         , HasType (Connection 'RW a) r
-         , a ~ a'
-         ) => MonadReadDB a' (DatabaseByType a m) where
-  askConnectionRO = DatabaseByType $ connectionRO <$> asks (^. typed @(Connection 'RW a))
+         , HasType (Connection 'RW) r
+         ) => MonadReadDB (DatabaseByType m) where
+  askConnectionRO = DatabaseByType $ connectionRO <$> asks (^. typed @(Connection 'RW))
   {-# INLINE askConnectionRO #-}
 
 instance ( MonadReader r m
-         , HasType (Connection 'RW a) r
-         , a ~ a'
-         ) => MonadDB a' (DatabaseByType a m) where
+         , HasType (Connection 'RW) r
+         ) => MonadDB (DatabaseByType m) where
   askConnectionRW = DatabaseByType $ asks (^. typed)
   {-# INLINE askConnectionRW #-}
 
@@ -381,17 +372,43 @@ instance ( MonadReader r m
 -- | Newtype wrapper which allows to derive 'MonadReadDB' and
 --   'MonadDB' instances using deriving via mechanism when connection
 --   is carried by reader.
-newtype DatabaseByReader a m x = DatabaseByReader (m x)
+newtype DatabaseByReader m x = DatabaseByReader (m x)
   deriving newtype (Functor,Applicative,Monad)
 
-instance ( MonadReader (Connection 'RW a) m
-         , a ~ a'
-         ) => MonadReadDB a' (DatabaseByReader a m) where
+instance ( MonadReader (Connection 'RW) m
+         ) => MonadReadDB (DatabaseByReader m) where
   askConnectionRO = DatabaseByReader $ connectionRO <$> ask
   {-# INLINE askConnectionRO #-}
 
-instance ( MonadReader (Connection 'RW a) m
-         , a ~ a'
-         ) => MonadDB a' (DatabaseByReader a m) where
+instance ( MonadReader (Connection 'RW) m
+         ) => MonadDB (DatabaseByReader m) where
   askConnectionRW = DatabaseByReader ask
   {-# INLINE askConnectionRW #-}
+
+
+-- | Newtype wrapper which allows to derive 'MonadReadDB' and
+--   'MonadDB' instances using deriving via mechanism by specifying name
+--   of field in record carried by reader.
+newtype CachedByField conn a m x = CachedByField (m x)
+  deriving newtype (Functor,Applicative,Monad)
+
+instance ( MonadReader r m
+         , a ~ a'
+         , HasField' conn r (Cached a)
+         ) => MonadCached a (CachedByField conn a' m) where
+  askCached = CachedByField $ asks (^. field' @conn)
+
+
+
+
+-- | Newtype wrapper which allows to derive 'MonadReadDB' and
+--   'MonadDB' instances using deriving via mechanism by using type of
+--   field in record carried by reader.
+newtype CachedByType a m x = CachedByType (m x)
+  deriving newtype (Functor,Applicative,Monad)
+
+instance ( MonadReader r m
+         , a ~ a'
+         , HasType (Cached a) r
+         ) => MonadCached a (CachedByType a' m) where
+  askCached = CachedByType $ asks (^. typed @(Cached a))

--- a/hschain/HSChain/Store.hs
+++ b/hschain/HSChain/Store.hs
@@ -33,9 +33,6 @@ module HSChain.Store (
   , queryRO
   , queryRW
   , mustQueryRW
-  , queryROT
-  , queryRWT
-  , mustQueryRWT
     -- ** Opening\/closing database
   , openConnection
   , closeConnection
@@ -47,7 +44,6 @@ module HSChain.Store (
   , MonadQueryRO(..)
   , MonadQueryRW(..)
   , Query
-  , QueryT
     -- ** Standard DB wrapper
   , DatabaseByField(..)
   , DatabaseByType(..)

--- a/hschain/HSChain/Store/Internal/BlockDB.hs
+++ b/hschain/HSChain/Store/Internal/BlockDB.hs
@@ -473,7 +473,7 @@ retrieveUnrecordedEvidence = do
 -- Helpers
 ----------------------------------------------------------------
 
-query1 :: (SQL.ToRow p, SQL.FromField x, MonadQueryRO a m)
+query1 :: (SQL.ToRow p, SQL.FromField x, MonadQueryRO m)
        => SQL.Query -> p -> m (Maybe x)
 query1 sql p =
   basicQuery sql p >>= \case
@@ -482,7 +482,7 @@ query1 sql p =
     _        -> error "Impossible"
 
 -- Query that returns 0 or 1 result which is CBOR-encoded value
-singleQ :: (SQL.ToRow p, Serialise x, MonadQueryRO a m)
+singleQ :: (SQL.ToRow p, Serialise x, MonadQueryRO m)
         => SQL.Query -> p -> m (Maybe x)
 singleQ sql p = (fmap . fmap) unCBORed
               $ query1 sql p

--- a/hschain/HSChain/Store/Internal/Query.hs
+++ b/hschain/HSChain/Store/Internal/Query.hs
@@ -237,8 +237,8 @@ rollback = liftQueryRW $ Query $ throwM Rollback
 
 
 basicCacheGenesis
-  :: Query 'RO a (Maybe (Block a))
-  -> Query 'RO a (Maybe (Block a))
+  :: Query rw a (Maybe (Block a))
+  -> Query rw a (Maybe (Block a))
 basicCacheGenesis (Query query) = Query $ do
   ref <- asks connCacheGen
   liftIO (readIORef ref) >>= \case
@@ -247,9 +247,9 @@ basicCacheGenesis (Query query) = Query $ do
                   liftIO $ b <$ atomicWriteIORef ref b
 
 basicCacheHeightObj
-  :: (Connection 'RO a -> IORef (LRU.LRU Height obj))
-  -> (Height -> Query 'RO a (Maybe obj))
-  ->  Height -> Query 'RO a (Maybe obj)
+  :: (Connection rw a -> IORef (LRU.LRU Height obj))
+  -> (Height -> Query rw a (Maybe obj))
+  ->  Height -> Query rw a (Maybe obj)
 basicCacheHeightObj cache query h = Query $ do
   ref <- asks cache
   r   <- liftIO (atomicModifyIORef' ref (LRU.lookup h))
@@ -260,13 +260,13 @@ basicCacheHeightObj cache query h = Query $ do
                   return mb
 
 basicCacheBlock
-  :: (Height -> Query 'RO a (Maybe (Block a)))
-  ->  Height -> Query 'RO a (Maybe (Block a))
+  :: (Height -> Query rw a (Maybe (Block a)))
+  ->  Height -> Query rw a (Maybe (Block a))
 basicCacheBlock = basicCacheHeightObj connCacheBlk
 
 basicCacheValidatorSet
-  :: (Height -> Query 'RO a (Maybe (ValidatorSet (Alg a))))
-  ->  Height -> Query 'RO a (Maybe (ValidatorSet (Alg a)))
+  :: (Height -> Query rw a (Maybe (ValidatorSet (Alg a))))
+  ->  Height -> Query rw a (Maybe (ValidatorSet (Alg a)))
 basicCacheValidatorSet = basicCacheHeightObj connCacheVSet
 
 basicPutCacheHeightObj

--- a/hschain/HSChain/Store/Internal/Query.hs
+++ b/hschain/HSChain/Store/Internal/Query.hs
@@ -8,8 +8,11 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
@@ -19,445 +22,231 @@
 -- many guarantees. Use with care.
 module HSChain.Store.Internal.Query (
     -- * Connection
-    Connection(..)
-  , connectionRO
-  , openConnection
-  , closeConnection
-  , withConnection
-  , MonadReadDB(..)
-  , MonadDB(..)
+    DB.Connection
+  , DB.connectionRO
+  , DB.openConnection
+  , DB.closeConnection
+  , DB.withConnection
+  , DB.MonadReadDB(..)
+  , DB.MonadDB(..)
     -- * MonadQuery
-  , MonadQueryRO(..)
-  , basicLastInsertRowId
-  , basicQuery
-  , basicQuery1
-  , basicQuery_
-  , basicExecute
-  , basicExecute_
+  , DB.MonadQueryRO(..)
+  , DB.MonadQueryRW(..)
+  , DB.basicLastInsertRowId
+  , DB.basicQuery
+  , DB.basicQuery1
+  , DB.basicQuery_
+  , DB.basicExecute
+  , DB.basicExecute_
+  , DB.rollback
+    -- * Caching
+    -- ** Data types & type classes
+  , Cache(..)
+  , Cached(..)
+  , newCached
+  , MonadCached(..)
+  , WithCache(..)
+    -- ** Query monad
+    -- ** Operations
   , basicCacheGenesis
   , basicCacheBlock
   , basicPutCacheBlock
   , basicPutValidatorSet
   , basicCacheValidatorSet
-  , rollback
-  , MonadQueryRW(..)
     -- * Database queries
   , Access(..)
     -- ** Plain queries
   , Query(..)
-  , runQueryRO
-  , runQueryRW
   , queryRO
   , queryRW
   , mustQueryRW
     -- * sqlite-simple helpers
-  , CBORed(..)
+  , DB.CBORed(..)
   ) where
 
-import Codec.Serialise                (Serialise, deserialise, serialise)
+import Control.Concurrent.MVar
 import Control.Monad
 import Control.Monad.Catch
-import qualified Control.Monad.Fail as Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Maybe
-import Control.Monad.Trans.State.Strict as SS(StateT(..))
+import Control.Monad.Trans.State.Strict as SS(StateT(..),get,put)
 import Control.Monad.Trans.State.Lazy   as SL(StateT(..))
 import Control.Monad.Trans.Except            (ExceptT(..))
 import Control.Monad.Trans.Identity          (IdentityT(..))
-import Data.Coerce
-import Data.IORef
-import Data.Int
+import Data.Tuple (swap)
+import Lens.Micro
+import Lens.Micro.TH
 import qualified Data.Cache.LRU                   as LRU
-import qualified Database.SQLite.Simple           as SQL
-import qualified Database.SQLite.Simple.ToField   as SQL
-import qualified Database.SQLite.Simple.FromField as SQL
 import Pipes (Proxy)
 
 import HSChain.Types.Blockchain
 import HSChain.Types.Validators
-import HSChain.Control.Mutex
-import HSChain.Control.Util
-import HSChain.Exceptions
-
+import           HSChain.Store.Query   (Access(..))
+import qualified HSChain.Store.Query as DB
 
 ----------------------------------------------------------------
 -- Connection to SQL database
 ----------------------------------------------------------------
 
--- | Access rights for storage or whether database queries alter
---   underlying data
-data Access = RO                -- ^ Read-only access
-            | RW                -- ^ Read-write access
-            deriving (Show)
+-- | Newtype wrapper holding MVar with cache for database
+--   requests. It's used outside of transaction and carried around in
+--   some sort of reader monad.
+newtype Cached a = Cached (MVar (Cache a))
 
--- | Connection to database for storage of blocks and user's
---   state. It's tagged by level of access, cryptographic algorithm,
---   and type of block. Latter two are needed to facilitate type
---   inference for functions like
---   'HSChain.Store.retrieveBlock' where @alg@ &
---   @a@ appear only in return type and frequently couldn't be
---   inferred without explicit type annotations.
-data Connection (rw :: Access) a = Connection
-  { connMutex    :: !Mutex
-  , connConn     :: !SQL.Connection
-  , connClosed   :: !(IORef Bool)
-  , connCacheGen :: !(IORef (Maybe (Block a)))
-  , connCacheBlk :: !(IORef (LRU.LRU Height (Block a)))
-  , connCacheVSet :: !(IORef (LRU.LRU Height (ValidatorSet (Alg a))))
+newCached :: MonadIO m => m (Cached a)
+newCached = liftIO $ Cached <$> newMVar Cache
+  { _cacheGen  = Nothing
+  , _cacheBlk  = LRU.newLRU (Just 8)
+  , _cacheVSet = LRU.newLRU (Just 8)
   }
 
--- | Convert read-only or read-write connection to read-only one.
-connectionRO :: Connection rw a -> Connection 'RO a
-connectionRO = coerce
+-- | Monad which has access to mutable reference holding cache for
+--   database requests.
+class Monad m => MonadCached a m | m -> a where
+  askCached :: m (Cached a)
 
--- | Open connection to database and set necessary pragmas
-openConnection :: MonadIO m => FilePath -> m (Connection rw a)
-openConnection db = liftIO $ do
-  connMutex    <- newMutex
-  connConn     <- SQL.open db
-  connClosed   <- newIORef False
-  connCacheGen <- newIORef Nothing
-  connCacheBlk <- newIORef $ LRU.newLRU (Just 8)
-  connCacheVSet <- newIORef $ LRU.newLRU (Just 8)
-  -- SQLite have support for retrying transactions in case database is
-  -- busy. Here we switch it on
-  SQL.execute_ connConn "PRAGMA busy_timeout = 10"
-  return $! Connection{..}
+-- | In-memory cache for database requests.
+data Cache a = Cache
+  { _cacheGen  :: !(Maybe (Block a))
+    -- ^ Genesis
+  , _cacheBlk  :: !(LRU.LRU Height (Block a))
+    -- ^ LRU cache for blocks
+  , _cacheVSet :: !(LRU.LRU Height (ValidatorSet (Alg a)))
+    -- ^ LRU cache for validator sets
+  }
 
--- | Close connection to database. Note that we can only close
---   connection if we have read-write acces to it.
-closeConnection :: MonadIO m => Connection 'RW a -> m ()
-closeConnection = closeConnection'
+$(makeLenses ''Cache)
 
-closeConnection' :: MonadIO m => Connection rw a -> m ()
-closeConnection' Connection{..} = liftIO $ do
-  uninterruptibleMask_ $ do
-    withMutex connMutex $ do
-      writeIORef connClosed True
-      SQL.close connConn
 
-withConnection
-  :: (MonadMask m, MonadIO m)
-  => FilePath -> (Connection rw a -> m x) -> m x
-withConnection db = bracket (openConnection db) closeConnection'
+-- | Monad which works with cache as state monad. It's meant to be
+--   used as part of transaction.
+class Monad m => WithCache a m | m -> a where
+  putCache :: Cache a -> m ()
+  getCache :: m (Cache a)
+
+----------------------------------------------------------------
+-- Query monad supporting querying
+----------------------------------------------------------------
+
+newtype Query rw a x = Query (SS.StateT (Cache a) (DB.Query rw) x)
+  deriving newtype ( Functor, Applicative, Monad, MonadThrow, MonadFail
+                   , DB.MonadQueryRO)
+
+deriving newtype instance (rw ~ 'RW) => DB.MonadQueryRW (Query rw a)
+
+instance WithCache a (Query rw a) where
+  getCache = Query   SS.get
+  putCache = Query . SS.put
+
+queryRO
+  :: (DB.MonadReadDB m, MonadCached a m, MonadIO m)
+  => Query 'RO a x -> m x
+queryRO (Query query) = do
+  conn      <- DB.askConnectionRO
+  Cached mv <- askCached
+  liftIO $ modifyMVar mv $ fmap swap . DB.runQueryRO conn . SS.runStateT query
+
+queryRW
+  :: (DB.MonadDB m, MonadCached a m, MonadIO m)
+  => Query 'RW a x -> m (Maybe x)
+queryRW (Query query) = do
+  conn      <- DB.askConnectionRW
+  Cached mv <- askCached
+  liftIO $ modifyMVar mv $ \c -> do
+    res <- DB.runQueryRW conn $ SS.runStateT query c
+    return $ case res of
+      Nothing     -> (c , Nothing)
+      Just (a,c') -> (c', Just a )
+
+mustQueryRW
+  :: (DB.MonadDB m, MonadCached a m, MonadIO m)
+  => Query 'RW a x -> m x
+mustQueryRW (Query query) = do
+  conn      <- DB.askConnectionRW
+  Cached mv <- askCached
+  liftIO $ modifyMVar mv $ \c -> do
+    res <- DB.runQueryRW conn $ SS.runStateT query c
+    case res of
+      Nothing     -> throwM DB.UnexpectedRollback
+      Just (a,c') -> return (c', a)
+
+
+
 
 
 ----------------------------------------------------------------
--- Monadic API
+-- Primitives for caching
 ----------------------------------------------------------------
-
--- | Monad which provides access to read-only connection to
---   database. That is it provides access to read-only handle to
---   database. This type class is expected to be more common than
---   read\/write one since most of the writing is expected to be done
---   by library.
---
---   Default implementation uses lift.
-class Monad m => MonadReadDB a m | m -> a where
-  askConnectionRO :: m (Connection 'RO a)
-  --
-  default askConnectionRO :: (m ~ t f, MonadReadDB a f, MonadTrans t)
-                          => m (Connection 'RO a)
-  askConnectionRO = lift askConnectionRO
-
--- | Monad which provides access to read-write connection to
---   database. It's half-internal API since user code shouldn't write
---   to the database and writing should be handled by library.
---
---   Default implementation uses lift.
-class MonadReadDB a m => MonadDB a m | m -> a where
-  askConnectionRW :: m (Connection 'RW a)
-  --
-  default askConnectionRW :: (m ~ t f, MonadDB a f, MonadTrans t)
-                          => m (Connection 'RW a)
-  askConnectionRW = lift askConnectionRW
-
--- | Monad which allows to perform read-only queries. API is just thin
---   wrappers about @sqlite-simple@ functions thus they shouldn't be
---   used directly. Also note that it doesn't have 'MonadIO' superclass.
-class Monad m => MonadQueryRO a m | m -> a where
-  liftQueryRO :: Query 'RO a x -> m x
-  --
-  default liftQueryRO :: (m ~ t f, MonadQueryRO a f, MonadTrans t)
-                      => Query 'RO a x -> m x
-  liftQueryRO = lift . liftQueryRO
-
--- | Monad which can perform read-write queries. @basic*RW@ functions
---   are same as @RO@ variants and intended to be used as
-class (MonadQueryRO a m) => MonadQueryRW a m | m -> a where
-  liftQueryRW :: Query rw a x -> m x
-  --
-  default liftQueryRW :: (m ~ t f, MonadQueryRW a f, MonadTrans t)
-                      => Query rw a x -> m x
-  liftQueryRW = lift . liftQueryRW
-
-basicQuery1 :: (SQL.ToRow row, SQL.FromRow x, MonadQueryRO a m)
-  => SQL.Query             -- ^ SQL query
-  -> row                   -- ^ Query parameters
-  -> m (Maybe x)
-basicQuery1 sql param =
-  basicQuery sql param >>= \case
-    []  -> return Nothing
-    [x] -> return $ Just x
-    _   -> error "Impossible"
-
-basicLastInsertRowId :: Query 'RW a Int64
-basicLastInsertRowId = Query $ do
-  conn <- asks connConn
-  liftIO $ SQL.lastInsertRowId conn
-
-basicQuery :: (MonadQueryRO a m, SQL.ToRow p, SQL.FromRow q) => SQL.Query -> p -> m [q]
-basicQuery sql p = liftQueryRO $ Query $ do
-  conn <- asks connConn
-  liftIO $ SQL.query conn sql p
-
-basicQuery_ :: (MonadQueryRO a m, SQL.FromRow q) => SQL.Query -> m [q]
-basicQuery_ sql = liftQueryRO $ Query $ do
-  conn <- asks connConn
-  liftIO $ SQL.query_ conn sql
-
-
-basicExecute :: (MonadQueryRW a m, SQL.ToRow p) => SQL.Query -> p -> m ()
-basicExecute sql param = liftQueryRW $ Query $ do
-  conn <- asks connConn
-  liftIO $ SQL.execute conn sql param
-
-basicExecute_ :: (MonadQueryRW a m) => SQL.Query -> m ()
-basicExecute_ sql = liftQueryRW $ Query $ do
-  conn <- asks connConn
-  liftIO $ SQL.execute_ conn sql
-
--- | Roll back execution of transaction. It's executed as throwing
---   of exception which is caught in the 'runQueryT'. Thus other
---   effects in monadic stack may or may not be rolled back as well.
-rollback :: (MonadQueryRW a m) => m x
-rollback = liftQueryRW $ Query $ throwM Rollback
-
 
 basicCacheGenesis
-  :: Query rw a (Maybe (Block a))
-  -> Query rw a (Maybe (Block a))
-basicCacheGenesis (Query query) = Query $ do
-  ref <- asks connCacheGen
-  liftIO (readIORef ref) >>= \case
+  :: WithCache a m => m (Maybe (Block a)) -> m (Maybe (Block a))
+basicCacheGenesis query = do
+  c <- getCache
+  case c^.cacheGen of
     Just b  -> return (Just b)
     Nothing -> do !b <- query
-                  liftIO $ b <$ atomicWriteIORef ref b
-
-basicCacheHeightObj
-  :: (Connection rw a -> IORef (LRU.LRU Height obj))
-  -> (Height -> Query rw a (Maybe obj))
-  ->  Height -> Query rw a (Maybe obj)
-basicCacheHeightObj cache query h = Query $ do
-  ref <- asks cache
-  r   <- liftIO (atomicModifyIORef' ref (LRU.lookup h))
-  case r of
-    Just _  -> return r
-    Nothing -> do mb <- unQuery $ query h
-                  liftIO $ forM_ mb $ \b -> atomicModifyIORef' ref $ (,()) . LRU.insert h b
-                  return mb
+                  putCache $ c & cacheGen .~ b
+                  return b
 
 basicCacheBlock
-  :: (Height -> Query rw a (Maybe (Block a)))
-  ->  Height -> Query rw a (Maybe (Block a))
-basicCacheBlock = basicCacheHeightObj connCacheBlk
+  :: WithCache a m
+  => (Height -> m (Maybe (Block a)))
+  -> (Height -> m (Maybe (Block a)))
+basicCacheBlock = basicCacheLRU cacheBlk
 
 basicCacheValidatorSet
-  :: (Height -> Query rw a (Maybe (ValidatorSet (Alg a))))
-  ->  Height -> Query rw a (Maybe (ValidatorSet (Alg a)))
-basicCacheValidatorSet = basicCacheHeightObj connCacheVSet
+  :: WithCache a m
+  => (Height -> m (Maybe (ValidatorSet (Alg a))))
+  -> (Height -> m (Maybe (ValidatorSet (Alg a))))
+basicCacheValidatorSet = basicCacheLRU cacheVSet
 
-basicPutCacheHeightObj
-  :: (Connection 'RW a -> IORef (LRU.LRU Height obj))
-  -> Height -> obj -> Query 'RW a ()
-basicPutCacheHeightObj cache h obj = Query $ do
-  ref <- asks cache
-  liftIO $ atomicModifyIORef' ref $ (,()) . LRU.insert h obj
+basicPutCacheBlock :: WithCache a m => Block a -> m ()
+basicPutCacheBlock b = basicPutCacheLRU cacheBlk (blockHeight b) b
 
-basicPutCacheBlock :: Block a -> Query 'RW a ()
-basicPutCacheBlock b = basicPutCacheHeightObj connCacheBlk (blockHeight b) b
+basicPutValidatorSet :: WithCache a m => Height -> ValidatorSet (Alg a) -> m ()
+basicPutValidatorSet = basicPutCacheLRU cacheVSet
 
-basicPutValidatorSet :: Height -> ValidatorSet (Alg a) -> Query 'RW a ()
-basicPutValidatorSet = basicPutCacheHeightObj connCacheVSet
 
-instance MonadReadDB  a m => MonadReadDB  a (IdentityT m)
-instance MonadDB      a m => MonadDB      a (IdentityT m)
-instance MonadQueryRO a m => MonadQueryRO a (IdentityT m)
-instance MonadQueryRW a m => MonadQueryRW a (IdentityT m)
+basicCacheLRU
+  :: (WithCache a m, Ord k)
+  => Lens' (Cache a) (LRU.LRU k b)
+  -> (k -> m (Maybe b))
+  -> (k -> m (Maybe b))
+basicCacheLRU len query h = do
+  c <- getCache
+  case h `LRU.lookup` (c^.len) of
+    (cb, Just b ) -> do putCache (c & len .~ cb)
+                        return (Just b)
+    (_ , Nothing) -> do mb <- query h
+                        forM_ mb $ \b -> putCache $ c & len %~ LRU.insert h b
+                        return mb
 
-instance MonadReadDB  a m => MonadReadDB  a (MaybeT m)
-instance MonadDB      a m => MonadDB      a (MaybeT m)
-instance MonadQueryRO a m => MonadQueryRO a (MaybeT m)
-instance MonadQueryRW a m => MonadQueryRW a (MaybeT m)
-
-instance MonadReadDB  a m => MonadReadDB  a (ExceptT e m)
-instance MonadDB      a m => MonadDB      a (ExceptT e m)
-instance MonadQueryRO a m => MonadQueryRO a (ExceptT e m)
-instance MonadQueryRW a m => MonadQueryRW a (ExceptT e m)
-
-instance MonadReadDB  a m => MonadReadDB  a (ReaderT r m)
-instance MonadDB      a m => MonadDB      a (ReaderT r m)
-instance MonadQueryRO a m => MonadQueryRO a (ReaderT r m)
-instance MonadQueryRW a m => MonadQueryRW a (ReaderT r m)
-
-instance MonadReadDB  a m => MonadReadDB  a (SS.StateT s m)
-instance MonadDB      a m => MonadDB      a (SS.StateT s m)
-instance MonadQueryRO a m => MonadQueryRO a (SS.StateT s m)
-instance MonadQueryRW a m => MonadQueryRW a (SS.StateT s m)
-
-instance MonadReadDB  a m => MonadReadDB  a (SL.StateT s m)
-instance MonadDB      a m => MonadDB      a (SL.StateT s m)
-instance MonadQueryRO a m => MonadQueryRO a (SL.StateT s m)
-instance MonadQueryRW a m => MonadQueryRW a (SL.StateT s m)
-
-instance MonadReadDB a m => MonadReadDB a (Proxy x x' y y' m)
-instance MonadDB     a m => MonadDB     a (Proxy x x' y y' m)
-
-----------------------------------------------------------------
--- Monad transformer
-----------------------------------------------------------------
-
--- | Exception thrown in order to roll back transaction
-data Rollback = Rollback
-  deriving (Show,Eq)
-instance Exception Rollback
-
+basicPutCacheLRU
+  :: (WithCache a m, Ord k)
+  => Lens' (Cache a) (LRU.LRU k b) -> k -> b -> m ()
+basicPutCacheLRU len h b = do
+  c <- getCache
+  putCache $ c & len %~ LRU.insert h b
 
 
 ----------------------------------------------------------------
--- Query monad
+-- Instances
 ----------------------------------------------------------------
 
--- | Query which doesn't allow any other effect except interaction
---   with database.
-newtype Query rw a x = Query { unQuery :: ReaderT (Connection rw a) IO x }
-  deriving newtype (Functor, Applicative, MonadThrow)
+instance MonadCached x m => MonadCached x (Proxy a b c d m) where
+  askCached = lift askCached
 
-instance Monad (Query rw a) where
-  return = Query . return
-  Query m >>= f = Query $ (\(Query q) -> q) . f =<< m
-#if !MIN_VERSION_base(4,11,0)
-  fail _ = Query $ throwM Rollback
-#endif
-
-instance Fail.MonadFail (Query rw a) where
-  fail _ = Query $ throwM Rollback
-
-instance MonadQueryRO a (Query rw a) where
-  -- NOTE: We need coerce to implement both:
-  --        - Query 'RO -> Query 'RO
-  --        - Query 'RO -> Query 'RW
-  liftQueryRO = coerce
-
-instance MonadQueryRW a (Query 'RW a) where
-  -- NOTE: We need coerce to implement both:
-  --        - Query 'RO -> Query 'RW
-  --        - Query 'RW -> Query 'RW
-  liftQueryRW = coerce
-
--- | Run read-only query. Note that read-only couldn't be rolled back
---   so they always succeed
-runQueryRO
-  :: (MonadIO m)
-  => Connection rw a
-  -> Query 'RO a x -> m x
-runQueryRO c (Query q) = liftIO $ do
-  r <- runQueryWorker False c $ runReaderT q (connectionRO c)
-  case r of
-    Nothing -> error "Query 'RO couldn't be rolled back"
-    Just a  -> return a
-
--- | Run read-write query
-runQueryRW
-  :: (MonadIO m)
-  => Connection 'RW a
-  -> Query 'RW a x
-  -> m (Maybe x)
-runQueryRW c (Query q) = liftIO $ runQueryWorker True c $ runReaderT q c
-
--- | Run read-only query using Query monad. Note that read-only
---   couldn't be rolled back so they always succeed.
-queryRO
-  :: (MonadReadDB a m, MonadIO m)
-  => Query 'RO a x
-  -> m x
-queryRO q = flip runQueryRO q =<< askConnectionRO
-
--- | Run read-write query using Query monad. Return @Nothing@ is query
---   was rolled back
-queryRW
-  :: (MonadDB a m, MonadIO m)
-  => Query 'RW a x
-  -> m (Maybe x)
-queryRW q = flip runQueryRW q =<< askConnectionRW
-
--- | Run read-write query using Query monad. Throws
---   'UnexpectedRollback' exception if query is rolled back was rolled
---   back.
-mustQueryRW
-  :: (MonadDB a m, MonadThrow m, MonadIO m)
-  => Query 'RW a x
-  -> m x
-mustQueryRW q
-  = throwNothing UnexpectedRollback =<< flip runQueryRW q =<< askConnectionRW
-
-
-----------------------------------------------------------------
--- Implementation
-----------------------------------------------------------------
-
-runQueryWorker
-  :: (MonadIO m, MonadMask m)
-  => Bool
-  -> Connection rw a
-  -> m x -> m (Maybe x)
-runQueryWorker isWrite connection sql = withMutex mutex $ do
-  closed <- liftIO $ readIORef $ connClosed connection
-  when closed $ throwM DatabaseIsClosed
-  uninterruptibleMask $ \restore -> do
-    -- This function is rather tricky to get right. We need to maintain
-    -- following invariant: No matter what happens we MUST call either
-    -- ROLLBACK or COMMIT after BEGIN TRANSACTION. Otherwise database
-    -- will be left inside a transaction and any attempt to start
-    -- another will be met with error about nested transactions.
-    --
-    -- It seems that functions from sqlite-simple are interruptible so
-    -- we need to use uninterruptibleMask
-    --
-    --  * BEGIN TRANSACTION does not acquire lock. It's deferred and
-    --    lock is acquired only when database is actually accessed. So
-    --    it's fast
-    --
-    --  * Neither ROLLBACK nor COMMIT should block but may take time for
-    --    IO operations but that's inevitable
-    --
-    -- Therefore usage of uninterruptibleMask is justified
-    --
-    -- See following links for details
-    --  + https://www.sqlite.org/lang_transaction.html
-    --  + https://www.sqlite.org/lockingv3.html
-    liftIO $ SQL.execute_ conn $
-      if isWrite then "BEGIN TRANSACTION IMMEDIATE" else "BEGIN TRANSACTION"
-    r <- try $ restore sql `onError` rollbackTx
-    case r of Left  Rollback -> return Nothing
-              Right x        -> do commitTx
-                                   return $ Just x
-  where
-    rollbackTx = liftIO $ SQL.execute_ conn "ROLLBACK"
-    commitTx   = liftIO $ SQL.execute_ conn "COMMIT"
-    mutex      = connMutex connection
-    conn       = connConn  connection
-
-
--- | Newtype wrapper which provides CBOR-encoded To\/FromField
---   instance for values
-newtype CBORed a = CBORed { unCBORed :: a }
-  deriving Show
-
-instance (Serialise a) => SQL.FromField (CBORed a) where
-  fromField f = CBORed . deserialise <$> SQL.fromField f
-
-instance (Serialise a) => SQL.ToField (CBORed a) where
-  toField (CBORed a) = SQL.toField (serialise a)
+instance MonadCached a m => MonadCached a (SS.StateT s m) where
+  askCached = lift askCached
+instance MonadCached a m => MonadCached a (SL.StateT s m) where
+  askCached = lift askCached
+instance MonadCached a m => MonadCached a (ReaderT r m) where
+  askCached = lift askCached
+instance MonadCached a m => MonadCached a (IdentityT m) where
+  askCached = lift askCached
+instance MonadCached a m => MonadCached a (MaybeT m) where
+  askCached = lift askCached
+instance MonadCached a m => MonadCached a (ExceptT e m) where
+  askCached = lift askCached

--- a/hschain/hschain.cabal
+++ b/hschain/hschain.cabal
@@ -27,8 +27,10 @@ Library
                      , hschain-config
                      , hschain-types
                      , hschain-logger
+                     , hschain-db
                      , hschain-net
                      , hschain-merkle
+                     --
                      , aeson
                      , base58-bytestring >=0.1
                      , bytestring        >=0.10

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -44,6 +44,7 @@ let
     hschain-types          = callInternal hsPkgs "hschain" ../hschain-types          {} "";
     hschain-merkle         = callInternal hsPkgs "hschain" ../hschain-merkle         {} "";
     hschain-logger         = callInternal hsPkgs "hschain" ../hschain-logger         {} "";
+    hschain-db             = callInternal hsPkgs "hschain" ../hschain-db             {} "";
     hschain-net            = callInternal hsPkgs "hschain" ../hschain-net            {} "";
     hschain-config         = callInternal hsPkgs "hschain" ../hschain-config         {} "";
     hschain-pow-func       = callInternal hsPkgs "hschain" ../proof-of-work          {} "";
@@ -85,6 +86,7 @@ let
       hschain-quickcheck
       hschain-control
       hschain-net
+      hschain-db
       hschain-pow-func
       hschain-PoW
       hschain


### PR DESCRIPTION
    Main purpose of this change is to split working with sqlite and building
    transactions into separate package and to use application specific caching. For
    example hschain has different caching requirements from hschain-PoW.
