### PR TITLE
Sz/better block generation

### DIFF
--- a/hschain-PoW/HSChain/Examples/Simple.hs
+++ b/hschain-PoW/HSChain/Examples/Simple.hs
@@ -83,7 +83,7 @@ instance KVConfig cfg => BlockData (KV cfg) where
   newtype BlockID (KV cfg) = KV'BID (Hash SHA256)
     deriving newtype (Show,Eq,Ord,CryptoHashable,Serialise, JSON.ToJSON, JSON.FromJSON)
 
-  type Tx (KV cfg) = ()
+  type Tx (KV cfg) = (Int, String)
   blockID b = let Hashed h = hashed b in KV'BID h
   validateHeader bh (Time now) header
     | blockHeight header == 0 = return True -- skip genesis check.

--- a/hschain-PoW/HSChain/PoW/Node.hs
+++ b/hschain-PoW/HSChain/PoW/Node.hs
@@ -134,7 +134,7 @@ runNode pathsToConfig miningNode genesisBlock step inventHeaderTxs inventBlock s
                     Just h
                       | bhHeight newBestHead > h -> return ()
                     _ -> do
-                         Just newBlock <- uncurry inventBlock newHeaderTxs
+                         Just newBlock <- liftIO $ uncurry inventBlock newHeaderTxs
                          mineLoop newBestHead =<< fork (doMine newBlock)
                 Nothing -> mineLoop baseBestHead tid
         --
@@ -147,7 +147,7 @@ runNode pathsToConfig miningNode genesisBlock step inventHeaderTxs inventBlock s
                    (toMine, cc') = consensusComputeOnState cc $ inventHeaderTxs bchBH
                writeTVar cv cc'
                return (bchBH, toMine)
-            Just startBlock <- uncurry inventBlock headerTxs
+            Just startBlock <- liftIO $ uncurry inventBlock headerTxs
             mineLoop startBestHead =<< fork (doMine startBlock)
           else liftIO $ forever $ threadDelay maxBound
 

--- a/hschain-PoW/HSChain/PoW/Node.hs
+++ b/hschain-PoW/HSChain/PoW/Node.hs
@@ -77,7 +77,7 @@ data Cfg = Cfg
 runNode :: forall b s . (BlockData b, Mineable b, Show (b Identity), Serialise (b Proxy), Serialise (b Identity))
         => [String] -> Bool -> Block b
         -> (Block b -> s -> Maybe s)
-        -> (BH b -> s -> (Block b, s))
+        -> (BH b -> s -> ((Header b, [TX]) s))
         -> s
         -> IO ()
 runNode pathsToConfig miningNode genesisBlock step inventBlock startState = do

--- a/hschain-PoW/exe/pow-node.hs
+++ b/hschain-PoW/exe/pow-node.hs
@@ -134,7 +134,7 @@ genesisNewPoW = GBlock
 -- and also fetches transactions from the state. The state may be modified
 -- along the way so we return it.
 getHeaderTxsToMine :: (Default (Nonce cfg), KVConfig cfg)
-          => BH (KV cfg) -> a -> ((Header (KV cfg), [()]), a)
+          => BH (KV cfg) -> a -> ((Header (KV cfg), [Tx (KV cfg)]), a)
 getHeaderTxsToMine bh a = ((toHeader $ GBlock
     { blockHeight = succ $ bhHeight bh
     , blockTime   = Time 0
@@ -151,7 +151,7 @@ getHeaderTxsToMine bh a = ((toHeader $ GBlock
 -- So here we mostly copy fields from header except of transaction list.
 -- The transaction list includes reward transaction and all other transactions produced
 -- by @getHeaderTxsToMine@.
-getBlockToMine :: String -> Header (KV cfg) -> [()] -> IO (Maybe (Block (KV cfg)))
+getBlockToMine :: String -> Header (KV cfg) -> [Tx (KV cfg)] -> IO (Maybe (Block (KV cfg)))
 getBlockToMine val hdr txs = do
   let mockRewardTx = (fromIntegral (blockHeight hdr), val)
   return $ Just $ hdr


### PR DESCRIPTION
The problem is that operation on consensus state (which includes blockchain state with the mempool state) must be pure. And in some contexts generation of reward transactions must be in IO.

Thus, interface to invent a block to mine was changed to two functions: pure function to obtain a good header and list of transactions to include into block and IO action to create a block from header and list of transactions, including the aforementioned reward transaction.

That's all.