### PR TITLE
Small tweaks to PoW code

### DIFF
--- a/hschain-PoW/HSChain/Examples/Simple.hs
+++ b/hschain-PoW/HSChain/Examples/Simple.hs
@@ -42,10 +42,10 @@ data KV cfg f = KV
   { kvData       :: !(MerkleNode f SHA256 [(Int,String)])
   -- ^ List of key-value pairs
   , kvTarget     :: !Target
-  -- ^ Nonce which is used to get
-  , kvNonce      :: !(Nonce cfg)
   -- ^ Current difficulty of mining. It means a complicated thing
   -- right now.
+  , kvNonce      :: !(Nonce cfg)
+  -- ^ Nonce which is used to get
   }
   deriving stock (Generic)
 deriving stock instance (Show (Nonce cfg), Show1 f)  => Show (KV cfg f)

--- a/hschain-PoW/HSChain/Examples/Simple.hs
+++ b/hschain-PoW/HSChain/Examples/Simple.hs
@@ -84,7 +84,7 @@ instance KVConfig cfg => BlockData (KV cfg) where
     deriving newtype (Show,Eq,Ord,CryptoHashable,Serialise, JSON.ToJSON, JSON.FromJSON)
 
   type Tx (KV cfg) = (Int, String)
-  blockID b = let Hashed h = hashed b in KV'BID h
+  blockID = KV'BID . hash
   validateHeader bh (Time now) header
     | blockHeight header == 0 = return True -- skip genesis check.
     | otherwise = do

--- a/hschain-PoW/HSChain/PoW/Node.hs
+++ b/hschain-PoW/HSChain/PoW/Node.hs
@@ -21,7 +21,8 @@
 {-# LANGUAGE TypeFamilies        #-}
 
 module HSChain.PoW.Node
-  ( runNode
+  ( Cfg(..)
+  , runNode
   , inMemoryView
   , inMemoryDB
   ) where


### PR DESCRIPTION
    Export Cfg from HSChain.PoW.Node

    Do not return Target from adjustPuzzle:   
     1) it's not used
     2) it could be calculated from block if needed
     3) only existing instance returns dummy value
