### PR TITLE
Add block storage backed by database

### DIFF
--- a/hschain-PoW/HSChain/PoW/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/Consensus.hs
@@ -158,10 +158,20 @@ makeLocator  = Locator . takeH 10 . Just
 -- Blockchain state handling
 ----------------------------------------------------------------
 
+-- | API for append only block storage. It should always contain
+--   genesis block.
 data BlockDB m b = BlockDB
-  { storeBlock     :: Block b -> m ()
-  , retrieveBlock  :: BlockID b -> m (Maybe (Block  b))
+  { storeBlock :: Block b -> m ()
+    -- ^ Put block into storage. It should be idempotent. That is
+    --   storing block already in storage should be a noop.
+  , retrieveBlock :: BlockID b -> m (Maybe (Block  b))
+    -- ^ Retrive complete block by its identifier
   , retrieveHeader :: BlockID b -> m (Maybe (Header b))
+    -- ^ Retrieve header by its identifier
+  , retrieveAllHeaders :: m [Header b]
+    -- ^ Retrieve all headers from storage in topologically sorted
+    --   order. (Ordering block by height would achieve that for
+    --   example).
   }
 
 -- | View on state of blockchain. It's expected that store is backed

--- a/hschain-PoW/HSChain/PoW/Node.hs
+++ b/hschain-PoW/HSChain/PoW/Node.hs
@@ -1,3 +1,17 @@
+{-# LANGUAGE ApplicativeDo       #-}
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE DerivingVia         #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
 -- |HSChain.PoW.Node.hs
 --
 -- Main node loop.
@@ -5,21 +19,6 @@
 -- You may use it directly or copy and tailor.
 --
 -- Copyright (C) ... 2020
-
-{-# LANGUAGE ApplicativeDo       #-}
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeFamilies        #-}
-
 module HSChain.PoW.Node
   ( Cfg(..)
   , runNode
@@ -32,22 +31,16 @@ import Codec.Serialise
 
 import Control.Concurrent
 import Control.Concurrent.STM
-
 import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.Cont
 import Control.Monad.Trans.Cont
 
 import Data.IORef
-
 import qualified Data.Map.Strict as Map
-
 import Data.Word
-
 import Data.Yaml.Config
-
 import GHC.Generics (Generic)
-
 import Lens.Micro
 
 import HSChain.PoW.Consensus
@@ -60,6 +53,7 @@ import HSChain.Network.Types
 import HSChain.Types.Merkle.Types
 import HSChain.Control.Util
 import HSChain.Control.Class
+import HSChain.Config
 
 -- |Node's configuration.
 data Cfg = Cfg
@@ -68,8 +62,9 @@ data Cfg = Cfg
   , cfgLog   :: [ScribeSpec]
   , cfgMaxH  :: Maybe Height
   }
-  deriving stock    (Show, Generic)
-  deriving anyclass (JSON.FromJSON)
+  deriving stock (Show, Generic)
+  deriving (JSON.FromJSON) via SnakeCase (DropSmart (Config Cfg))
+
 
 -- |The process to run nodes.
 --

--- a/hschain-PoW/HSChain/PoW/Node.hs
+++ b/hschain-PoW/HSChain/PoW/Node.hs
@@ -222,7 +222,7 @@ blockDatabase genesis = do
       --
     , retrieveHeader = \bid -> queryRO $ do
         r <- basicQuery1
-          "SELECT height, time, prev, blockHeader FROM pow_blocks WHERE bid = ?"
+          "SELECT height, time, prev, headerData FROM pow_blocks WHERE bid = ?"
           (Only (CBORed bid))
         case r of
           Just (blockHeight, blockTime, (fmap unCBORed -> prevBlock), CBORed blockData)
@@ -230,7 +230,7 @@ blockDatabase genesis = do
           Nothing -> return Nothing
     , retrieveAllHeaders = queryRO $ do
         r <- basicQuery_
-          "SELECT height, time, prev, blockHeader FROM pow_blocks ORDER BY height"
+          "SELECT height, time, prev, headerData FROM pow_blocks ORDER BY height"
         return [ GBlock{..}
                | (blockHeight, blockTime, (fmap unCBORed -> prevBlock), CBORed blockData) <- r ]
     }

--- a/hschain-PoW/hschain-PoW.cabal
+++ b/hschain-PoW/hschain-PoW.cabal
@@ -111,7 +111,10 @@ Test-suite hschain-PoW-tests
                      , hschain-control
                      , hschain-merkle
                      , hschain-logger
+                     , hschain-db
                      , hschain-net
+                     --
+                     , exceptions
                      , containers
                      , serialise
                      , transformers

--- a/hschain-PoW/hschain-PoW.cabal
+++ b/hschain-PoW/hschain-PoW.cabal
@@ -127,4 +127,5 @@ Test-suite hschain-PoW-tests
   Main-is:             Main.hs
   Other-modules:       TM.Consensus
                        TM.P2P
+                       TM.Store
                        TM.Util.Mockchain

--- a/hschain-PoW/hschain-PoW.cabal
+++ b/hschain-PoW/hschain-PoW.cabal
@@ -26,6 +26,8 @@ Library
                      , hschain-net
                      , hschain-merkle
                      , hschain-pow-func
+                     , hschain-db
+                       --
                      , aeson
                      , base58-bytestring >=0.1
                      , bytestring        >=0.10

--- a/hschain-PoW/hschain-PoW.cabal
+++ b/hschain-PoW/hschain-PoW.cabal
@@ -21,6 +21,7 @@ Library
   Build-Depends:       base              >=4.9 && <5
                      , hschain-crypto
                      , hschain-control
+                     , hschain-config
                      , hschain-logger
                      , hschain-net
                      , hschain-merkle

--- a/hschain-PoW/test/Main.hs
+++ b/hschain-PoW/test/Main.hs
@@ -2,9 +2,11 @@ import Test.Tasty
 
 import qualified TM.Consensus
 import qualified TM.P2P
+import qualified TM.Store
 
 main :: IO ()
 main = defaultMain $ testGroup "hschain"
   [ TM.Consensus.tests
   , TM.P2P.tests
+  , TM.Store.tests
   ]

--- a/hschain-PoW/test/TM/Consensus.hs
+++ b/hschain-PoW/test/TM/Consensus.hs
@@ -296,7 +296,7 @@ data Message
 
 runTest :: [Message] -> IO ()
 runTest msgList = runNoLogsT $ do
-  db <- inMemoryDB
+  db <- inMemoryDB genesis
   let s0 = consensusGenesis (head mockchain) $
                             inMemoryView kvViewStep Map.empty (blockID genesis)
   runExceptT (loop db s0 msgList) >>= \case

--- a/hschain-PoW/test/TM/P2P.hs
+++ b/hschain-PoW/test/TM/P2P.hs
@@ -128,7 +128,7 @@ recvM = TestM $ do
 -- We use PEX setting which preclude it from sending any messages
 runNetTest :: TestM () -> IO ()
 runNetTest test = do
-  db  <- inMemoryDB @_ @_ @(KV MockChain)
+  db  <- inMemoryDB genesis
   net <- newMockNet
   let s0 = consensusGenesis (head mockchain) $
             inMemoryView kvViewStep Map.empty (blockID genesis)

--- a/hschain-PoW/test/TM/Store.hs
+++ b/hschain-PoW/test/TM/Store.hs
@@ -1,0 +1,47 @@
+-- |
+module TM.Store (tests) where
+
+import Control.Monad
+import Control.Monad.IO.Class
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import HSChain.PoW.Consensus
+import HSChain.PoW.Types
+import HSChain.PoW.Node
+import HSChain.Examples.Simple (KV)
+import HSChain.Store.Query (withConnection)
+import TM.Util.Mockchain
+
+tests :: TestTree
+tests = testGroup "Block store"
+  [ testCase "idempotence/In-memory" $ testIdempotence =<< inMemoryDB genesis
+  , testCase "idempotence/DB"
+    $ withConnection "" $ \conn -> runHSChainT conn $ testIdempotence =<< blockDatabase genesis
+  ]
+
+testIdempotence :: MonadIO m => BlockDB m (KV MockChain) -> m ()
+testIdempotence db = do
+  -- Genesis
+  fetch "Genesis" genesis
+  storeBlock db genesis
+  fetch "Genesis" genesis
+  -- Rest of blocks
+  forM_ (take 3 $ drop 1 mockchain) $ \b -> do
+    nofetch (show (blockHeight b)) b
+  -- Store and retrieve
+  forM_ (take 3 $ drop 1 mockchain) $ \b -> do
+    storeBlock db b
+    fetch ("Stored: "++show (blockHeight b)) b
+  -- Idempotency of store
+  forM_ (take 3 $ drop 1 mockchain) $ \b -> do
+    storeBlock db b
+    fetch ("Idempotence: "++show (blockHeight b)) b
+  -- Fetchall
+  liftIO . assertEqual "All headers" (take 4 $ map toHeader $ mockchain) =<< retrieveAllHeaders db
+  where
+    fetch   nm b = liftIO . assertEqual ("Yes: " ++ nm) (Just b)
+               =<< retrieveBlock db (blockID b)
+    nofetch nm b = liftIO . assertEqual ("No: " ++ nm) (Nothing)
+               =<< retrieveBlock db (blockID b)
+

--- a/hschain-PoW/test/TM/Util/Mockchain.hs
+++ b/hschain-PoW/test/TM/Util/Mockchain.hs
@@ -1,19 +1,28 @@
-{-# LANGUAGE FlexibleContexts             #-}
-{-# LANGUAGE TypeFamilies                 #-}
-{-# LANGUAGE UndecidableInstances         #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 -- |
 module TM.Util.Mockchain where
 
 import Codec.Serialise
 import Control.Applicative
+import Control.Monad.Catch
+import Control.Monad.Reader
 import Data.Bits
-import Data.Word
 import Data.List  (unfoldr)
+import Data.Word
 
 import System.IO.Unsafe (unsafePerformIO)
 
 import HSChain.PoW.Types
+import HSChain.Logger
+import HSChain.Control.Class
+import HSChain.Store.Query
 import HSChain.Types.Merkle.Types
 import HSChain.Examples.Simple
 
@@ -94,3 +103,17 @@ header2' = toHeader block2'
 header3' = toHeader block3'
 header4' = toHeader block4'
 
+
+
+-- | Monad transformer for use in tests
+newtype HSChainT m x = HSChainT (ReaderT (Connection 'RW) m x)
+  deriving newtype (Functor,Applicative,Monad,MonadIO,MonadFail)
+  deriving newtype (MonadThrow,MonadCatch,MonadMask,MonadFork)
+  deriving newtype (MonadReader (Connection 'RW))
+  -- HSChain instances
+  deriving MonadLogger            via NoLogsT          (HSChainT m)
+  deriving (MonadReadDB, MonadDB) via DatabaseByReader (HSChainT m)
+
+runHSChainT :: Connection 'RW -> HSChainT m x -> m x
+runHSChainT c (HSChainT m) = do
+  runReaderT m c

--- a/hschain-db/HSChain/Store/Query.hs
+++ b/hschain-db/HSChain/Store/Query.hs
@@ -66,6 +66,8 @@ module HSChain.Store.Query (
   , DatabaseByField(..)
   , DatabaseByType(..)
   , DatabaseByReader(..)
+    -- * Reexports
+  , SQL.Only(..)
   ) where
 
 import Codec.Serialise                (Serialise, deserialise, serialise)


### PR DESCRIPTION
This PR adds both database-backed storage for blocks and extend in order accommodate future restoration of state from database:

- Function for fetching headers
- Functions for building block index  & finding better heads. 

Also adds tests for storage