### PR TITLE
Add better logging to PoW

### DIFF
--- a/hschain-PoW/HSChain/PoW/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/Consensus.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns         #-}
 {-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE DerivingStrategies   #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE LambdaCase           #-}
@@ -53,12 +54,14 @@ import Data.Maybe
 import Data.Sequence      (Seq(Empty,(:<|),(:|>)),(|>))
 import Data.Set           (Set)
 import Data.Ord           (Down(..))
+import qualified Data.Aeson      as JSON
 import qualified Data.Map        as Map
 import qualified Data.Set        as Set
 import qualified Data.Sequence   as Seq
 import Lens.Micro
 import Lens.Micro.Mtl
 import Lens.Micro.TH
+import GHC.Generics (Generic)
 
 import HSChain.Types.Merkle.Types
 import HSChain.PoW.Types
@@ -257,14 +260,14 @@ data HeaderError
     -- ^ We don't have parent block
   | ErrH'ValidationFailure
   | ErrH'BadParent
-  deriving stock    (Show,Eq)
-  deriving anyclass (Exception)
+  deriving stock    (Show,Eq,Generic)
+  deriving anyclass (Exception,JSON.ToJSON,JSON.FromJSON)
 
 data BlockError
   = ErrB'UnknownBlock
   | ErrB'InvalidBlock
-  deriving stock    (Show,Eq)
-  deriving anyclass (Exception)
+  deriving stock    (Show,Eq,Generic)
+  deriving anyclass (Exception,JSON.ToJSON,JSON.FromJSON)
 
 
 ----------------------------------------------------------------

--- a/hschain-PoW/HSChain/PoW/P2P/Handler/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Handler/Consensus.hs
@@ -59,6 +59,9 @@ threadConsensus db consensus0 ConsensusCh{..} = descendNamespace "cns" $ logOnEx
          sinkIO sinkReqBlocks   =<< use requiredBlocks
          (bh',st,_) <- use bestHead
          when (bhBID bh /= bhBID bh') $ do
+           logger InfoS "New head" ( sl "h"   (bhHeight bh')
+                                  <> sl "bid" (bhBID bh')
+                                   )
            sinkIO bcastAnnounce $ AnnBestHead $ asHeader bh'
            sinkIO bcastChainUpdate (bh',st)
 

--- a/hschain-PoW/HSChain/PoW/P2P/Handler/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Handler/Consensus.hs
@@ -94,12 +94,15 @@ consensusMonitor db (BoxRX message)
         Right () -> return Peer'Noop
         Left  e  -> case e of
           ErrH'KnownHeader       -> return Peer'Noop
-          ErrH'HeightMismatch    -> return $ Peer'Punish $ toException e
-          ErrH'ValidationFailure -> return $ Peer'Punish $ toException e
-          ErrH'BadParent         -> return $ Peer'Punish $ toException e
+          ErrH'HeightMismatch    -> punish
+          ErrH'ValidationFailure -> punish
+          ErrH'BadParent         -> punish
           -- We got announce that we couldn't attach to block tree. So
           -- we need that peer to catch up
           ErrH'UnknownParent     -> return Peer'EnterCatchup
+          where
+            punish = do logger WarningS "Bad AnnBestHead" (sl "err" e)
+                        return $ Peer'Punish $ toException e
     -- Handle error conditions which happen when we process new block
     -- Note that we explicitly requrest blocks by their BIDs so we
     -- shouln't punish peers
@@ -109,14 +112,17 @@ consensusMonitor db (BoxRX message)
       Left ErrB'InvalidBlock -> Right ()
     -- Handle errors during header processing. Not that KnownHeader is
     -- not really an error
-    handleHeaderError = mapExceptT $ fmap $ \case
-      Right () -> Right ()
+    handleHeaderError = mapExceptT $ \action -> action >>= \case
+      Right () -> return $ Right ()
       Left  e  -> case e of
-        ErrH'KnownHeader       -> Right ()
-        ErrH'HeightMismatch    -> Left $ Peer'Punish $ toException e
-        ErrH'UnknownParent     -> Left $ Peer'Punish $ toException e
-        ErrH'ValidationFailure -> Left $ Peer'Punish $ toException e
-        ErrH'BadParent         -> Left $ Peer'Punish $ toException e
+        ErrH'KnownHeader       -> return $ Right ()
+        ErrH'HeightMismatch    -> punish
+        ErrH'UnknownParent     -> punish
+        ErrH'ValidationFailure -> punish
+        ErrH'BadParent         -> punish
+        where
+          punish = do logger WarningS "Bad header" (sl "err" e)
+                      return $ Left $ Peer'Punish $ toException e
     -- Convert error from ExceptT
     evalError action = runExceptT action >>= \case
       Right () -> return Peer'Noop


### PR DESCRIPTION
```
$ jq -C < logs/node-2.log 'select(.msg=="New head")|{at,msg,data}'
...
{
  "at": "2020-07-28T16:05:03.931059783Z",
  "msg": "New head",
  "data": {
    "bid": "BoUMYNSqWJsvnPN1HbsDWzi4fCpCAdkZiTw4DCuuiUo6",
    "h": 26
  }
}
{
  "at": "2020-07-28T16:05:03.931059783Z",
  "msg": "New head",
  "data": {
    "bid": "HBYjNvZeTw2F5Y8DYtbrEcsC9G7rxz5qp6nnSEBic7qy",
    "h": 27
  }
...
```