### PR TITLE
Add a way to access consensus-synched user state

### DIFF
--- a/hschain-PoW/HSChain/PoW/Node.hs
+++ b/hschain-PoW/HSChain/PoW/Node.hs
@@ -155,7 +155,7 @@ runNode pathsToConfig miningNode genesisBlock step inventHeaderTxs inventBlock m
                          mineLoop newBestHead =<< fork (doMine newBlock)
                 Nothing -> mineLoop baseBestHead tid
         --
-        liftIO $ runExternalAccessThread -- ^ Run the external access thread before going to mine or something.
+        liftIO $ runExternalAccessThread
         if miningNode
           then do
             (startBestHead, headerTxs) <- atomicallyIO $ do

--- a/hschain-PoW/exe/pow-node.hs
+++ b/hschain-PoW/exe/pow-node.hs
@@ -197,7 +197,7 @@ parser = do
 runNodeAnyPoW :: forall cfg . (Show (Nonce cfg), Default (Nonce cfg), KVConfig cfg)
               => Opts -> Block (KV cfg) ->IO ()
 runNodeAnyPoW Opts{..} genesisBlock = do
-  runNode cmdConfigPath optMine genesisBlock kvViewStep getHeaderTxsToMine (getBlockToMine optNodeName) Map.empty
+  runNode cmdConfigPath optMine genesisBlock kvViewStep getHeaderTxsToMine (getBlockToMine optNodeName) Nothing Map.empty
 
 main :: IO ()
 main = do


### PR DESCRIPTION
Just another function for runNode that allows us to access (within STM) our state - view UTXO sets, add transactions, etc.