### PR TITLE
Move BlockIndex & BlockDB into separate modules

### DIFF
--- a/hschain-PoW/HSChain/Examples/Coin.hs
+++ b/hschain-PoW/HSChain/Examples/Coin.hs
@@ -83,6 +83,7 @@ instance BlockData Coin where
 
   blockID = CoinID   . hash
   txID    = CoinTxID . hash
+  blockTransactions = merkleValue . coinData . blockData
 
   validateTxContextFree = undefined
 

--- a/hschain-PoW/HSChain/Examples/Simple.hs
+++ b/hschain-PoW/HSChain/Examples/Simple.hs
@@ -84,6 +84,7 @@ class ( CryptoHashable (Nonce cfg)
   -- |How to check solution of a puzzle.
   kvCheckPuzzle :: MonadIO m => Header (KV cfg) -> m Bool
 
+
 instance (KVConfig cfg) => BlockData (KV cfg) where
   newtype BlockID (KV cfg) = KV'BID (Hash SHA256)
     deriving newtype (Show,Eq,Ord,CryptoHashable,Serialise, JSON.ToJSON, JSON.FromJSON)
@@ -99,6 +100,7 @@ instance (KVConfig cfg) => BlockData (KV cfg) where
 
   blockID = KV'BID . hash
   txID    = KV'TID . hash
+  blockTransactions = merkleValue . kvData . blockData
 
   validateTxContextFree _ = Right ()
 

--- a/hschain-PoW/HSChain/PoW/BlockIndex.hs
+++ b/hschain-PoW/HSChain/PoW/BlockIndex.hs
@@ -1,0 +1,114 @@
+-- |
+-- Block index is data structure which holds headers for all blocks in
+-- blockchain in memory. This module provides data structure and set
+-- of common operations for working with it.
+{-# LANGUAGE FlexibleContexts #-}
+module HSChain.PoW.BlockIndex  
+  ( -- * Block index
+    BlockIndex(..)
+  , lookupIdx
+  , insertIdx
+  -- * Traversals
+  , traverseBlockIndex
+  , traverseBlockIndexM
+  -- * Construction of index
+  , blockIndexHeads
+  , blockIndexFromGenesis
+  ) where
+
+import Control.Monad
+import Data.Foldable
+import Data.Functor.Identity
+import Data.Map              (Map,(!))
+import qualified Data.Map        as Map
+import qualified Data.Set        as Set
+
+import HSChain.PoW.Types
+import HSChain.Types.Merkle.Types
+
+
+----------------------------------------------------------------
+-- Block index
+----------------------------------------------------------------
+
+-- | Tree of block headers. It's append-only data supports which
+--   supports looking up header by block ID and 'BH' contain reference
+--   to previous block. When working with @BlockIndex@ one should take
+--   care to maximize sharing.
+newtype BlockIndex b = BlockIndex
+  -- FIXME: We'll want to add blocks incrementally into compact to
+  --        make things easier for GC
+  { _blockIDMap :: Map (BlockID b) (BH b)
+  }
+
+-- | Find header in block index using it's ID.
+lookupIdx :: (Ord (BlockID b)) => BlockID b -> BlockIndex b -> Maybe (BH b)
+lookupIdx bid (BlockIndex idx) = Map.lookup bid idx
+
+-- | Add header to block index. @bhPrevious@ field of header should
+--   point to value already in the index.
+insertIdx :: (Ord (BlockID b)) => BH b -> BlockIndex b -> BlockIndex b
+insertIdx bh (BlockIndex idx) = BlockIndex $ Map.insert (bhBID bh) bh idx
+
+
+-- | Find path between nodes in block index
+traverseBlockIndex
+  :: (BlockData b)
+  => (BH b -> a -> a)         -- ^ Rollback block
+  -> (BH b -> a -> a)         -- ^ Update update block
+  -> BH b                     -- ^ Traverse from block
+  -> BH b                     -- ^ Traverse to block
+  -> (a -> a)
+traverseBlockIndex rollback update fromB toB
+  = runIdentity
+  . traverseBlockIndexM
+    (\b -> Identity . rollback b)
+    (\b -> Identity . update   b)
+    fromB toB
+
+-- | Find path between nodes in block index
+traverseBlockIndexM
+  :: (Monad m, BlockData b)
+  => (BH b -> a -> m a)         -- ^ Rollback block
+  -> (BH b -> a -> m a)         -- ^ Update update block
+  -> BH b                       -- ^ Traverse from block
+  -> BH b                       -- ^ Traverse to block
+  -> (a -> m a)
+traverseBlockIndexM rollback update = go
+  where
+    go fromB toB = case bhHeight fromB `compare` bhHeight toB of
+      GT                -> rollback fromB >=> go (prev fromB) toB
+      LT                ->                    go fromB        (prev toB) >=> update toB
+      EQ | toB /= fromB -> rollback fromB >=> go (prev fromB) (prev toB) >=> update toB
+         | otherwise    -> return
+    prev b = case bhPrevious b of
+      Just b' -> b'
+      Nothing -> error "Internal error"
+
+
+
+-- | Find all heads from index: blocks which aren't parents of some
+--   other blocks. Requires complete traversal of index.
+blockIndexHeads :: (Ord (BlockID b)) => BlockIndex b -> [BH b]
+blockIndexHeads (BlockIndex bMap)
+  = fmap (\bid -> bMap ! bid)
+  $ toList
+  $ foldl' remove (Map.keysSet bMap) (Map.toList bMap)
+  where
+    remove bids (bid, BH{bhPrevious = Nothing}) = Set.delete bid bids
+    remove bids (_  , BH{bhPrevious = Just bh}) = Set.delete (bhBID bh) bids
+
+-- | Create block index which contains only genesis
+blockIndexFromGenesis :: (IsMerkle f, BlockData b) => GBlock b f -> BlockIndex b
+blockIndexFromGenesis genesis
+  | blockHeight genesis /= Height 0 = error "Genesis must be H=0"
+  | otherwise                       = BlockIndex $ Map.singleton bid bh
+  where
+    bid = blockID genesis
+    bh  = BH { bhHeight   = Height 0
+             , bhTime     = blockTime genesis
+             , bhBID      = bid
+             , bhWork     = blockWork genesis
+             , bhPrevious = Nothing
+             , bhData     = merkleMap (const Proxy) $ blockData genesis
+             }

--- a/hschain-PoW/HSChain/PoW/Store.hs
+++ b/hschain-PoW/HSChain/PoW/Store.hs
@@ -1,0 +1,152 @@
+-- |
+-- API and default implementation for storage of blocks. Normally
+-- blocks are meant to be stored in the database but for testing and
+-- debugging it could be useful to have in-memory storage as well.
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE LambdaCase #-}
+module HSChain.PoW.Store
+  ( -- * API and generic functions
+    BlockDB(..)
+  , buildBlockIndex
+    -- * Implementations
+  , inMemoryDB
+  , blockDatabase
+  ) where
+
+import Codec.Serialise (Serialise)
+import Control.Monad.IO.Class
+import Control.Monad.Catch
+import Data.Foldable
+import Data.Functor.Identity
+import Data.IORef
+import Data.List (sortOn)
+import Data.Proxy
+import qualified Data.Map.Strict as Map
+
+import HSChain.Types.Merkle.Types
+import HSChain.Store.Query
+import HSChain.PoW.Types
+import HSChain.PoW.BlockIndex
+
+
+----------------------------------------------------------------
+-- Block database
+----------------------------------------------------------------
+
+-- | API for append only block storage. It should always contain
+--   genesis block.
+data BlockDB m b = BlockDB
+  { storeBlock :: Block b -> m ()
+    -- ^ Put block into storage. It should be idempotent. That is
+    --   storing block already in storage should be a noop.
+  , retrieveBlock :: BlockID b -> m (Maybe (Block  b))
+    -- ^ Retrive complete block by its identifier
+  , retrieveHeader :: BlockID b -> m (Maybe (Header b))
+    -- ^ Retrieve header by its identifier
+  , retrieveAllHeaders :: m [Header b]
+    -- ^ Retrieve all headers from storage in topologically sorted
+    --   order. (Ordering block by height would achieve that for
+    --   example).
+  }
+
+-- | Build block index from blocks
+buildBlockIndex :: (Monad m, BlockData b) => BlockDB m b -> m (BlockIndex b)
+buildBlockIndex BlockDB{..} = do
+  -- FIXME: decide what to do with orphan blocks
+  (genesis,headers) <- retrieveAllHeaders >>= \case
+    genesis:headers -> return (genesis,headers)
+    []              -> error "buildBlockIndex: no blocks in storage"
+  --
+  let idx0      = blockIndexFromGenesis genesis
+      add idx b@GBlock{..} = case (`lookupIdx` idx) =<< prevBlock of
+        Nothing     -> error "blockIndexFromGenesis: orphan block"
+        Just parent -> insertIdx BH
+          { bhHeight   = blockHeight
+          , bhTime     = blockTime
+          , bhBID      = blockID b
+          , bhWork     = bhWork parent <> blockWork b
+          , bhPrevious = Just parent
+          , bhData     = blockData
+          } idx
+  return $! foldl' add idx0 headers
+
+
+----------------------------------------------------------------
+-- Implementations
+----------------------------------------------------------------
+
+-- | Very simple block storage which holds all blocks in memory. Only
+--   useful for testing, debugging, and prototyping.
+inMemoryDB
+  :: (MonadIO m, MonadIO n, BlockData b)
+  => Block b
+  -> m (BlockDB n b)
+inMemoryDB genesis = do
+  var <- liftIO $ newIORef $ Map.singleton (blockID genesis) genesis
+  return BlockDB
+    { storeBlock         = \b   -> liftIO $ modifyIORef' var $ Map.insert (blockID b) b
+    , retrieveBlock      = \bid -> liftIO $ Map.lookup bid <$> readIORef var
+    , retrieveHeader     = \bid -> liftIO $ fmap toHeader . Map.lookup bid <$> readIORef var
+    , retrieveAllHeaders = liftIO $ sortOn blockHeight . map toHeader . toList <$> readIORef var
+    }
+
+
+
+-- | Block storage backed by SQLite database. It's most generic
+--   storage which just stores
+blockDatabase
+  :: ( MonadThrow m, MonadIO m, MonadDB m
+     , BlockData b, Serialise (b Proxy), Serialise (b Identity))
+  => Block b
+  -> m (BlockDB m b)
+blockDatabase genesis = do
+  -- First we initialize database schema
+  mustQueryRW $ basicExecute_
+    "CREATE TABLE IF NOT EXISTS pow_blocks \
+    \  ( id         INTEGER PRIMARY KEY AUTOINCREMENT \
+    \  , bid        BLOB NOT NULL UNIQUE \
+    \  , height     INTEGER NOT NULL \
+    \  , time       INTEGER NUT NULL \
+    \  , prev       BLOB NULL \
+    \  , headerData BLOB NOT NULL \
+    \  , blockData  BLOB NOT NULL )"
+  store genesis
+  return BlockDB
+    { storeBlock = store
+      --
+    , retrieveBlock  = \bid -> queryRO $ basicQueryWith1
+        decoderBlock
+        "SELECT height, time, prev, blockData FROM pow_blocks WHERE bid = ?"
+        (Only (CBORed bid))
+      --
+    , retrieveHeader = \bid -> queryRO $ basicQueryWith1
+        decoderHeader
+        "SELECT height, time, prev, headerData FROM pow_blocks WHERE bid = ?"
+        (Only (CBORed bid))
+      --
+    , retrieveAllHeaders = queryRO $ basicQueryWith_
+        decoderHeader
+        "SELECT height, time, prev, headerData FROM pow_blocks ORDER BY height"
+    }
+    where
+      decoderBlock  = do blockHeight <- field
+                         blockTime   <- field
+                         prevBlock   <- nullableFieldCBOR
+                         blockData   <- fieldCBOR
+                         return GBlock{..}
+      decoderHeader = do blockHeight <- field
+                         blockTime   <- field
+                         prevBlock   <- nullableFieldCBOR
+                         blockData   <- fieldCBOR
+                         return GBlock{..}
+      --
+      store b@GBlock{..} = mustQueryRW $ basicExecute
+        "INSERT OR IGNORE INTO pow_blocks VALUES (NULL, ?, ?, ?, ?, ?, ?)"
+        ( CBORed (blockID b)
+        , blockHeight
+        , blockTime
+        , CBORed <$> prevBlock
+        , CBORed (merkleMap (const Proxy) blockData)
+        , CBORed blockData
+        )

--- a/hschain-PoW/HSChain/PoW/Types.hs
+++ b/hschain-PoW/HSChain/PoW/Types.hs
@@ -121,6 +121,9 @@ class ( Show (BlockID b), Ord (BlockID b), Serialise (BlockID b)
   blockID :: IsMerkle f => GBlock b f -> BlockID b
   -- | Compute ID of a transaction.
   txID :: Tx b -> TxID b
+  -- | List of transactions in block
+  blockTransactions :: Block b -> [Tx b]
+
 
   -- | Context free validation of a transaction. It should perform all
   --   validations that are possible given only transacion.

--- a/hschain-PoW/hschain-PoW.cabal
+++ b/hschain-PoW/hschain-PoW.cabal
@@ -65,6 +65,7 @@ Library
                 HSChain.Examples.Util
                 HSChain.PoW.Exceptions
                 HSChain.PoW.Node
+                HSChain.PoW.Store
                 HSChain.PoW.P2P
                 HSChain.PoW.P2P.Types
                 HSChain.PoW.P2P.Handler.BlockRequests

--- a/hschain-PoW/hschain-PoW.cabal
+++ b/hschain-PoW/hschain-PoW.cabal
@@ -57,6 +57,7 @@ Library
                      , unordered-containers >=0.2.5.0
                      , yaml
   Exposed-modules:
+                HSChain.PoW.BlockIndex
                 HSChain.PoW.Types
                 HSChain.PoW.Consensus
                 HSChain.Examples.Coin

--- a/hschain-examples/HSChain/Mock/Coin.hs
+++ b/hschain-examples/HSChain/Mock/Coin.hs
@@ -177,9 +177,7 @@ inMemoryStateView valSet0 = do
                                         Right c' -> let (c'', b  ) = selectTx c' tx
                                                     in  (c'', t:b)
               let (st', dat) = selectTx st
-                             $ map merkleValue
-                             $ toList
-                             $ mempFIFO memSt
+                             $ toList memSt
               return
                 ( BData dat
                 , make (Just newBlockHeight) newBlockValSet dat st'
@@ -497,7 +495,7 @@ databaseStateView valSetH0 = do
                       Right d' -> second (t:) <$> selectTx d' tx
               --
               memSt <- getMempoolState
-              (diff',txs) <- queryRO $ selectTx diff $ map merkleValue $ toList $ mempFIFO memSt
+              (diff',txs) <- queryRO $ selectTx diff $ toList memSt
               return ( BData txs
                      , make (Just newBlockHeight) txs newBlockValSet diff'
                      )


### PR DESCRIPTION
Motivations is to break dependency loops when (so far nonexitent) mempool depends on BlockDB and Consensus depends on mempool