### PR TITLE
Reparametrize mempool

### DIFF
--- a/hschain-examples/HSChain/Mock/Coin.hs
+++ b/hschain-examples/HSChain/Mock/Coin.hs
@@ -147,7 +147,7 @@ inMemoryStateView
   -> m (StateView m BData, [m ()], IO CoinState)
 inMemoryStateView valSet0 = do
   varSt <- liftIO $ newIORef $ CoinState mempty mempty
-  (mem@Mempool{..}, memThr) <- newMempool (isRight . validateTxContextFree)
+  (mem@Mempool{..}, memThr) <- newMempool hashed (isRight . validateTxContextFree)
   let make mh vals txList st = r where
         r = StateView
           { stateHeight       = mh
@@ -448,7 +448,7 @@ databaseStateView
   => ValidatorSet (Alg BData)
   -> m (StateView m BData, [m ()])
 databaseStateView valSetH0 = do
-  (mem@Mempool{..}, memThr) <- newMempool (isRight . validateTxContextFree)
+  (mem@Mempool{..}, memThr) <- newMempool hashed (isRight . validateTxContextFree)
   -- First we find what is latest height at which we updated state and
   -- use it as startign point for our state management.
   (h0,valSet0) <- queryRO $ do
@@ -515,7 +515,7 @@ databaseStateView valSetH0 = do
 dbTransactionGenerator
   :: (MonadReadDB m, MonadCached BData m, MonadIO m)
   => TxGenerator
-  -> Mempool m (Alg BData) Tx
+  -> Mempool m (Hashed (Alg BData) Tx) Tx
   -> (Tx -> m ())
   -> m a
 dbTransactionGenerator gen mempool push = forever $ do

--- a/hschain-examples/HSChain/Mock/Dioxane.hs
+++ b/hschain-examples/HSChain/Mock/Dioxane.hs
@@ -70,7 +70,7 @@ inMemoryStateView valSet0 = make Nothing valSet0 (DioState mempty)
       viewS = StateView
         { stateHeight   = mh
         , newValidators = vals
-        , stateMempool  = nullMempool
+        , stateMempool  = nullMempool hashed
         , commitState   = return viewS
         -- 
         , validatePropBlock = \b valSet -> return $ maybe (Left DioError) Right $ do

--- a/hschain-examples/HSChain/Mock/KeyVal.hs
+++ b/hschain-examples/HSChain/Mock/KeyVal.hs
@@ -121,7 +121,7 @@ inMemoryStateView = make Nothing mempty
             return ( BData [tx]
                    , make (Just newBlockHeight) st' newBlockValSet 
                    )
-        , stateMempool = nullMempool
+        , stateMempool = nullMempool hashed
         }
 
 process :: Tx -> BState -> Either KeyValError BState

--- a/hschain-examples/test/TM/Validators.hs
+++ b/hschain-examples/test/TM/Validators.hs
@@ -213,7 +213,7 @@ inMemoryStateView = make Nothing
         { stateHeight   = mh
         , newValidators = vals
         , commitState   = return viewSt
-        , stateMempool  = nullMempool
+        , stateMempool  = nullMempool hashed
         --
         , validatePropBlock = \b _ -> return $ do
             let tx = merkleValue $ blockData b

--- a/hschain-mempool/hschain-mempool.cabal
+++ b/hschain-mempool/hschain-mempool.cabal
@@ -21,7 +21,6 @@ Library
   Build-Depends:       base              >=4.9 && <5
                      , hschain-crypto
                      , hschain-control
-                     , hschain-merkle
                      --
                      , aeson
                      , containers

--- a/hschain/HSChain/Internal/Types/Consensus.hs
+++ b/hschain/HSChain/Internal/Types/Consensus.hs
@@ -13,6 +13,7 @@ module HSChain.Internal.Types.Consensus (
   , Genesis(..)
   ) where
 
+import HSChain.Crypto
 import HSChain.Mempool
 import HSChain.Types.Blockchain
 import HSChain.Types.Validators
@@ -37,7 +38,7 @@ data StateView m a = StateView
   , generateCandidate  :: NewBlock a
                        -> m (a, StateView m a)
     -- ^ Generate new proposal for blockchain
-  , stateMempool       :: Mempool m (Alg a) (TX a)
+  , stateMempool       :: Mempool m (Hashed (Alg a) (TX a)) (TX a)
     -- ^ Mempool
   }
 

--- a/hschain/HSChain/P2P.hs
+++ b/hschain/HSChain/P2P.hs
@@ -26,6 +26,7 @@ import Katip                  (sl)
 import HSChain.Blockchain.Internal.Engine.Types
 import HSChain.Control.Class
 import HSChain.Control.Shepherd
+import HSChain.Crypto (Hashed)
 import HSChain.Control.Util
 import HSChain.Internal.Types.Config
 import HSChain.Internal.Types.Consensus
@@ -51,7 +52,7 @@ startPeerDispatcher
   -> NetworkAPI               -- ^ API for networking
   -> [NetAddr]                -- ^ Set of initial addresses to connect
   -> AppChans n a             -- ^ Channels for communication with main application
-  -> MempoolHandle (Alg a) (TX a)
+  -> MempoolHandle (Hashed (Alg a) (TX a)) (TX a)
   -> m ()
 startPeerDispatcher p2pCfg net addrs AppChans{..} mempool = logOnException $ do
   logger InfoS "Starting peer dispatcher" $ sl "seed" addrs

--- a/hschain/HSChain/P2P/Internal.hs
+++ b/hschain/HSChain/P2P/Internal.hs
@@ -41,6 +41,7 @@ import HSChain.Control.Class
 import HSChain.Control.Delay
 import HSChain.Control.Shepherd
 import HSChain.Control.Util
+import HSChain.Crypto (Hashed)
 import HSChain.Internal.Types.Config
 import HSChain.Internal.Types.Consensus
 import HSChain.Logger
@@ -69,7 +70,7 @@ acceptLoop
   => NetworkCfg app
   -> NetworkAPI
   -> PeerChans n a
-  -> MempoolHandle (Alg a) (TX a)
+  -> MempoolHandle (Hashed (Alg a) (TX a)) (TX a)
   -> m ()
 acceptLoop cfg NetworkAPI{..} peerCh mempool = do
   logger DebugS "Starting accept loop" ()
@@ -107,7 +108,7 @@ connectPeerTo
   => NetworkAPI
   -> NetAddr
   -> PeerChans n a
-  -> MempoolHandle (Alg a) (TX a)
+  -> MempoolHandle (Hashed (Alg a) (TX a)) (TX a)
   -> m ()
 connectPeerTo NetworkAPI{..} addr peerCh mempool =
   -- Ignore all exceptions to prevent apparing of error messages in stderr/stdout.
@@ -137,7 +138,7 @@ startPeer
   -> PeerChans n a         -- ^ Communication with main application
                            --   and peer dispatcher
   -> P2PConnection         -- ^ Functions for interaction with network
-  -> MempoolHandle (Alg a) (TX a)
+  -> MempoolHandle (Hashed (Alg a) (TX a)) (TX a)
   -> m ()
 startPeer peerAddrTo peerCh@PeerChans{..} conn mempool = logOnException $
   descendNamespace (T.pack (show peerAddrTo)) $ logOnException $ do
@@ -161,7 +162,7 @@ peerFSM
   => PeerChans n a
   -> TBQueue (GossipMsg a)
   -> TChan (GossipMsg a)
-  -> MempoolCursor (Alg a) (TX a)
+  -> MempoolCursor (Hashed (Alg a) (TX a)) (TX a)
   -> m ()
 peerFSM peerCh@PeerChans{..} gossipCh recvCh MempoolCursor{..} = logOnException $ do
   ownPeerChanTx <- atomicallyIO $ dupTChan peerChanTx
@@ -298,7 +299,7 @@ pexFSM
   => NetworkCfg app
   -> NetworkAPI
   -> PeerChans n a
-  -> MempoolHandle (Alg a) (TX a)
+  -> MempoolHandle (Hashed (Alg a) (TX a)) (TX a)
   -> m b
 pexFSM cfg net@NetworkAPI{..} peerCh@PeerChans{..} mempool = descendNamespace "PEX" $ do
   -- Start by connecting to peers


### PR DESCRIPTION
Instead of using plain hash pass transaction id as parameter. Needed for PoW
where TID is data family