### PR TITLE
Improve StdoutLogT

### DIFF
--- a/hschain-control/HSChain/Control/Via.hs
+++ b/hschain-control/HSChain/Control/Via.hs
@@ -1,0 +1,44 @@
+-- |
+-- Newtype wrappers for deriving instances for mtl's type
+-- classes. Their intended use is to generateinstances to be used with
+-- other via-deriving newtypes.
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE UndecidableInstances       #-}
+module HSChain.Control.Via
+  (
+  ) where
+
+import Control.Monad.Reader
+import Data.Generics.Product.Fields (HasField'(..))
+import Data.Generics.Product.Typed  (HasType(..))
+import Lens.Micro
+
+-- | Convert instance @MonadReader r@ into instance @MonadReader x@.
+--   Field @x@ of @r@ is looked up by its type
+newtype ReaderViaType x m a = ReaderViaType (m a)
+  deriving newtype (Functor,Applicative,Monad)
+
+instance ( MonadReader r m
+         , HasType x r
+         ) => MonadReader x (ReaderViaType x m) where
+  ask = ReaderViaType $ (^. (typed @x)) <$> ask
+  local f (ReaderViaType m) = ReaderViaType $ local (typed @x %~ f) m
+
+
+-- | Convert instance @MonadReader r@ into instance @MonadReader x@.
+--   Field @x@ of @r@ is looked up by its selector name @field@.
+newtype ReaderViaField field x m a = ReaderViaField (m a)
+  deriving newtype (Functor,Applicative,Monad)
+
+instance ( MonadReader r m
+         , HasField' field r x
+         ) => MonadReader x (ReaderViaField field x m) where
+  ask = ReaderViaField $ (^. (field' @field)) <$> ask
+  local f (ReaderViaField m) = ReaderViaField $ local (field' @field %~ f) m

--- a/hschain-control/hschain-control.cabal
+++ b/hschain-control/hschain-control.cabal
@@ -23,6 +23,9 @@ Library
                      , stm
                      , transformers
                      , containers
+                     , microlens         >=0.4.11
+                     , mtl               >=2
+                     , generic-lens
   Exposed-modules:
                   HSChain.Control.Channels
                   HSChain.Control.Class
@@ -30,3 +33,4 @@ Library
                   HSChain.Control.Shepherd
                   HSChain.Control.Util
                   HSChain.Control.Delay
+                  HSChain.Control.Via

--- a/hschain-logger/HSChain/Logger.hs
+++ b/hschain-logger/HSChain/Logger.hs
@@ -125,6 +125,9 @@ instance MonadIO m => MonadLogger (NoLogsT m) where
   localNamespace _ a = a
 
 
+-- | Newtype for converting 'MonadReader' instance to 'MonadLogger'
+--   instance. Fields for namespace and log environment are accessed
+--   using field names.
 newtype LoggerByFields logenv namespace m a = LoggerByFields (m a)
   deriving newtype (Functor, Applicative, Monad)
 
@@ -142,6 +145,9 @@ instance ( MonadReader r m
   {-# INLINE localNamespace #-}
 
 
+-- | Newtype for converting 'MonadReader' instance to 'MonadLogger'
+--   instance. Fields for namespace and log environment are accessed
+--   by their resepctive types.
 newtype LoggerByTypes m a = LoggerByTypes (m a)
   deriving newtype (Functor, Applicative, Monad)
 

--- a/hschain-logger/HSChain/Logger/Class.hs
+++ b/hschain-logger/HSChain/Logger/Class.hs
@@ -20,6 +20,15 @@ class Monad m => MonadLogger m where
   -- | Change current namespace
   localNamespace :: (Namespace -> Namespace) -> m a -> m a
 
+-- | Change logger's namespace
+setNamespace :: MonadLogger m => Namespace -> m a -> m a
+setNamespace nm = localNamespace (const nm)
+
+-- | Append string to namespace
+descendNamespace :: MonadLogger m => Text -> m a -> m a
+descendNamespace nm = localNamespace $ \(Namespace x) -> Namespace (x ++ [nm])
+
+
 instance MonadLogger m => MonadLogger (MaybeT m) where
   logger sev str a = lift $ logger sev str a
   localNamespace fun (MaybeT m) = MaybeT (localNamespace fun m)
@@ -43,11 +52,3 @@ instance MonadLogger m => MonadLogger (ExceptT e m) where
 instance MonadLogger m => MonadLogger (IdentityT m) where
   logger sev str a = lift $ logger sev str a
   localNamespace fun (IdentityT m) = IdentityT $ localNamespace fun m
-
--- | Change logger's namespace
-setNamespace :: MonadLogger m => Namespace -> m a -> m a
-setNamespace nm = localNamespace (const nm)
-
--- | Append string to namespace
-descendNamespace :: MonadLogger m => Text -> m a -> m a
-descendNamespace nm = localNamespace $ \(Namespace x) -> Namespace (x ++ [nm])

--- a/nix/derivations/haskell/generic-lens-core.nix
+++ b/nix/derivations/haskell/generic-lens-core.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, base, indexed-profunctors, stdenv, text }:
+mkDerivation {
+  pname = "generic-lens-core";
+  version = "2.0.0.0";
+  sha256 = "51628204350380be7d46a53a9e3e47d9d6f5c4797cf0215b9d93a2f90794ee40";
+  libraryHaskellDepends = [ base indexed-profunctors text ];
+  homepage = "https://github.com/kcsongor/generic-lens";
+  description = "Generically derive traversals, lenses and prisms";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/derivations/haskell/indexed-profunctors.nix
+++ b/nix/derivations/haskell/indexed-profunctors.nix
@@ -1,0 +1,9 @@
+{ mkDerivation, base, stdenv }:
+mkDerivation {
+  pname = "indexed-profunctors";
+  version = "0.1";
+  sha256 = "31dfb4319dff84199344000b1efad75158eeac17ddcbb27f91735e958591bb65";
+  libraryHaskellDepends = [ base ];
+  description = "Utilities for indexed profunctors";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/derivations/haskell/microlens.nix
+++ b/nix/derivations/haskell/microlens.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, base, stdenv }:
+mkDerivation {
+  pname = "microlens";
+  version = "0.4.11.2";
+  sha256 = "4e484d4a73c7c5176ccfdacc29aec7399352cac1c7e8924d5123857cf36ddffc";
+  libraryHaskellDepends = [ base ];
+  homepage = "http://github.com/monadfix/microlens";
+  description = "A tiny lens library with no dependencies";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/overrides.nix
+++ b/nix/overrides.nix
@@ -35,6 +35,7 @@
     tasty-quickcheck      = { check = false; };
     QuickCheck            = { check = false; };
     lens                  = { check = false; };
+    generic-lens          = { check = false; };
     comonad               = { check = false; };
     semigroupoids         = { check = false; };
     # Test have dependency on cryptonite


### PR DESCRIPTION
This is an attempt to improve logging. 

 - Newtype wrappers for derivingvia for mtl's type classes are added to hschain-control
 - StdoutLogT & new StdoutLogNoNamespaceT could be used with deriving via