### PR TITLE
Add state 

### DIFF
--- a/hschain-PoW/HSChain/Examples/Simple.hs
+++ b/hschain-PoW/HSChain/Examples/Simple.hs
@@ -182,7 +182,7 @@ kvMemoryView = make (error "No revinding past genesis") mempty
       where
         view = StateView
           { stateBID    = bid
-          , applyBlock  = \_ b -> case kvViewStep b s of
+          , applyBlock  = \_ _ b -> case kvViewStep b s of
               Nothing -> return $ Left KVError
               Just s' -> return $ Right $ make view s' (blockID b)
           , revertBlock = return previous

--- a/hschain-PoW/exe/coin-node.hs
+++ b/hschain-PoW/exe/coin-node.hs
@@ -115,7 +115,7 @@ inMemoryView = make (error "No revinding past genesis")
       where
         view = StateView
           { stateBID    = bid
-          , applyBlock  = \bh _ -> return $ Right $ make view (bhBID bh)
+          , applyBlock  = \_ bh _ -> return $ Right $ make view (bhBID bh)
           , revertBlock = return previous
           , flushState  = return view
           , checkTx                  = error "Transaction checking is not supported"

--- a/hschain-PoW/test/TM/Util/Mockchain.hs
+++ b/hschain-PoW/test/TM/Util/Mockchain.hs
@@ -123,7 +123,7 @@ inMemoryView = make (error "No revinding past genesis")
       where
         view = StateView
           { stateBID    = bid
-          , applyBlock  = \bh _ -> return $ Right $ make view (bhBID bh)
+          , applyBlock  = \_ bh _ -> return $ Right $ make view (bhBID bh)
           , revertBlock = return previous
           , flushState  = return view
           , checkTx                  = error "Transaction checking is not supported"


### PR DESCRIPTION
Turns out this is required for the DB-backed state storage since we need to
find path between state recorded in DB and current overlay and we need access to
block index for that