### PR TITLE
Fix bug in coin's state hadnling which caused crash on double spend

### DIFF
--- a/hschain-examples/HSChain/Mock/Coin.hs
+++ b/hschain-examples/HSChain/Mock/Coin.hs
@@ -15,6 +15,7 @@
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 -- |
 -- Very simple UTXO coin intended for demonstration of hschain. As a
 -- demonstration it doesn't have any sort of economics nor in form of
@@ -66,7 +67,10 @@ import Data.Either
 import Data.IORef
 import Data.Maybe
 import Data.Map             (Map,(!))
-import Database.SQLite.Simple             (Only(..))
+import Database.SQLite.Simple             (Only(..),(:.)(..))
+import qualified Database.SQLite.Simple.ToField   as SQL
+import qualified Database.SQLite.Simple.FromRow   as SQL
+import qualified Database.SQLite.Simple.ToRow     as SQL
 import qualified Data.Vector         as V
 import qualified Data.Map.Strict     as Map
 import qualified Data.Set            as Set
@@ -89,6 +93,7 @@ import HSChain.Mock
 import HSChain.Mock.Coin.Types
 import HSChain.Store
 import HSChain.Store.Internal.Query
+import HSChain.Store.Query          (fieldByteRepr,ByteRepred(..),field)
 import HSChain.Mock.KeyList         (makePrivKeyStream)
 import HSChain.Mock.Types
 import HSChain.Monitoring
@@ -335,6 +340,16 @@ findInputs tgt = go 0
 -- State stored in database
 ----------------------------------------------------------------
 
+instance SQL.FromRow Unspent where
+  fromRow = Unspent <$> fieldByteRepr <*> SQL.field
+instance SQL.ToRow Unspent where
+  toRow (Unspent k n) = [ SQL.toField (ByteRepred k), SQL.toField n ]
+
+instance SQL.FromRow UTXO where
+  fromRow = UTXO <$> field <*> fieldByteRepr
+instance SQL.ToRow UTXO where
+  toRow (UTXO n h) = [SQL.toField n, SQL.toField (ByteRepred h)]
+
 -- | Initialize tables for storage of coin state. Storage is heavily
 --   tailored towards particular use case of demonstartion and
 --   benchmarks for mock UTXO blockchain and likely won't work well
@@ -346,10 +361,10 @@ initCoinDB = do
   -- creted and spent
   basicExecute_
     "CREATE TABLE IF NOT EXISTS coin_utxo \
-    \  ( tx_hash BLOB    NOT NULL \
-    \  , n_out   INTEGER NOT NULL \
-    \  , n_coins INTEGER NOT NULL \
+    \  ( n_out   INTEGER NOT NULL \
+    \  , tx_hash BLOB    NOT NULL \
     \  , pk      BLOB    NOT NULL \
+    \  , n_coins INTEGER NOT NULL \
     \  , h_added INTEGER NOT NULL \
     \  , h_spent INTEGER NULL     \
     \  , UNIQUE (tx_hash,n_out)   \
@@ -374,18 +389,13 @@ data UtxoDiff = UtxoDiff
 dbLookupUTXO
   :: (MonadQueryRO m)
   => Height                 -- ^ Height of block for which we calculate state updates
-  -> Hashed (Alg BData) Tx  -- ^ Transaction hash
-  -> Int                    -- ^ Output number
+  -> UTXO
   -> m (Maybe Unspent)
-dbLookupUTXO h txHash nOut = do
-  r <- basicQuery1
-    "SELECT pk,n_coins FROM coin_utxo \
-    \ WHERE tx_hash = ? AND n_out = ? \
-    \   AND (h_spent is NULL OR h_spent >= ?)"
-    (encodeToBS txHash, nOut, h)
-  return $ case r of
-    Nothing     -> Nothing
-    Just (bs,n) -> Just $ Unspent (fromMaybe (error "Invalid value in DB") $ decodeFromBS bs) n
+dbLookupUTXO h utxo = basicQuery1
+  "SELECT pk,n_coins FROM coin_utxo \
+  \ WHERE n_out = ? AND tx_hash = ?\
+  \   AND (h_spent is NULL OR h_spent >= ?)"
+  (utxo :. Only h)
 
 dbProcessDeposit
   :: (Monad m)
@@ -402,11 +412,11 @@ dbProcessSend
 dbProcessSend _ Deposit{} _ = throwError DepositAtWrongH
 dbProcessSend h tx@(Send pk _ TxSend{..}) UtxoDiff{..} = do
   -- Try to find all inputs for transaction
-  inputs <- forM txInputs $ \utxo@(UTXO nOut txH) -> do
+  inputs <- forM txInputs $ \utxo -> do
     Unspent pk' n <- case utxo `Map.lookup` utxoDiff of
       Just (Added u _) -> return u
       Just _           -> throwError $ CoinError "Already spent output"
-      Nothing -> dbLookupUTXO baseH txH nOut >>= \case
+      Nothing -> dbLookupUTXO baseH utxo >>= \case
         Nothing -> throwError $ CoinError "Already spent output"
         Just x  -> return x
     unless (pk == pk') $ throwError $ CoinError "PublicKey mismatch"
@@ -433,16 +443,16 @@ dbProcessSend h tx@(Send pk _ TxSend{..}) UtxoDiff{..} = do
 dbRecordDiff
   :: (MonadQueryRW m)
   => (UTXO, UtxoChange) -> m ()
-dbRecordDiff (UTXO nOut txHash, change) = case change of
+dbRecordDiff (utxo, change) = case change of
   Spent h -> basicExecute
-    "UPDATE coin_utxo SET h_spent=? WHERE tx_hash=? AND n_out=?"
-    (h, encodeToBS txHash, nOut)
-  Added (Unspent pk i) h     -> basicExecute
+    "UPDATE coin_utxo SET h_spent=? WHERE n_out=? AND tx_hash=?"
+    (Only h :. utxo)
+  Added out h     -> basicExecute
     "INSERT INTO coin_utxo VALUES (?,?,?,?,?,NULL)"
-    (encodeToBS txHash, nOut, i, encodeToBS pk, h)
-  Both  (Unspent pk i) h1 h2 -> basicExecute
+    (utxo :. out :. Only h)
+  Both  out h1 h2 -> basicExecute
     "INSERT INTO coin_utxo VALUES (?,?,?,?,?,?)"
-    (encodeToBS txHash, nOut, i, encodeToBS pk, h1,h2)
+    (utxo :. out :. (h1,h2))
 
 databaseStateView
   :: (MonadIO m, MonadThrow m, MonadDB m, MonadCached BData m)

--- a/hschain-examples/HSChain/Mock/Coin.hs
+++ b/hschain-examples/HSChain/Mock/Coin.hs
@@ -38,6 +38,7 @@ module HSChain.Mock.Coin (
   , generateTransaction
     -- * In-DB state
   , initCoinDB
+  , databaseStateView
     -- * Interpretation
     -- ** Monad
   , CoinT(..)
@@ -404,7 +405,7 @@ dbProcessSend h tx@(Send pk _ TxSend{..}) UtxoDiff{..} = do
   inputs <- forM txInputs $ \utxo@(UTXO nOut txH) -> do
     Unspent pk' n <- case utxo `Map.lookup` utxoDiff of
       Just (Added u _) -> return u
-      Just _               -> throwError $ CoinError "Already spent output"
+      Just _           -> throwError $ CoinError "Already spent output"
       Nothing -> dbLookupUTXO baseH txH nOut >>= \case
         Nothing -> throwError $ CoinError "Already spent output"
         Just x  -> return x

--- a/hschain-examples/HSChain/Mock/Coin.hs
+++ b/hschain-examples/HSChain/Mock/Coin.hs
@@ -381,7 +381,7 @@ dbLookupUTXO h txHash nOut = do
   r <- basicQuery1
     "SELECT pk,n_coins FROM coin_utxo \
     \ WHERE tx_hash = ? AND n_out = ? \
-    \   AND (h_spent is NULL OR h_spent < ?)"
+    \   AND (h_spent is NULL OR h_spent >= ?)"
     (encodeToBS txHash, nOut, h)
   return $ case r of
     Nothing     -> Nothing

--- a/hschain-examples/HSChain/Mock/Coin.hs
+++ b/hschain-examples/HSChain/Mock/Coin.hs
@@ -587,7 +587,7 @@ data CoinDictM g = CoinDictM
 
 -- | Application monad for coin
 newtype CoinT g m a = CoinT { unCoinT :: ReaderT (CoinDictM g) m a }
-  deriving newtype (Functor,Applicative,Monad,MonadIO)
+  deriving newtype (Functor,Applicative,Monad,MonadIO,MonadFail)
   deriving newtype (MonadThrow,MonadCatch,MonadMask,MonadFork)
   -- HSChain instances
   deriving MonadLogger

--- a/hschain-examples/hschain-examples.cabal
+++ b/hschain-examples/hschain-examples.cabal
@@ -17,16 +17,17 @@ Library
   Ghc-options:         -Wall
   Default-Language:    Haskell2010
   Build-Depends:       base              >=4.12 && <5
-                     , hschain-crypto
-                     , hschain-control
-                     , hschain-logger
-                     , hschain-config
-                     , hschain-types
-                     , hschain-merkle
-                     , hschain-mempool
                      , hschain
-                     , hschain-net
+                     , hschain-config
+                     , hschain-control
+                     , hschain-crypto
+                     , hschain-db
                      , hschain-examples-types
+                     , hschain-logger
+                     , hschain-mempool
+                     , hschain-merkle
+                     , hschain-net
+                     , hschain-types
                        --
                      , aeson
                      , bytestring           >=0.10
@@ -178,6 +179,7 @@ Test-suite hschain-tests
   hs-source-dirs:      test
   Main-is:             Main.hs
   Other-modules:       TM.Consensus
+                       TM.Coin
                        TM.Integration
                        TM.Mempool
                        TM.P2P.Gossip

--- a/hschain-examples/test/Main.hs
+++ b/hschain-examples/test/Main.hs
@@ -7,6 +7,7 @@ import qualified TM.P2P.PEX
 import qualified TM.Serialisation
 import qualified TM.Integration
 import qualified TM.Validators
+import qualified TM.Coin
 
 main :: IO ()
 main = defaultMain $ testGroup "hschain"
@@ -17,6 +18,7 @@ main = defaultMain $ testGroup "hschain"
   , TM.P2P.PEX.tests
   , TM.P2P.Gossip.tests
   , TM.Consensus.tests
+  , TM.Coin.tests
   -- Integration tests
   , TM.Integration.tests
   -- Unsorted stuff

--- a/hschain-examples/test/TM/Coin.hs
+++ b/hschain-examples/test/TM/Coin.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+-- |
+module TM.Coin (tests) where
+
+import Control.Monad.State.Strict
+import Control.Monad.Reader
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import HSChain.Internal.Types.Consensus
+import HSChain.Crypto
+import HSChain.Types
+import HSChain.Store
+import HSChain.Store.Internal.BlockDB
+import HSChain.Mock.Coin
+import HSChain.Mock.KeyList
+import HSChain.Mock.Types   (makeGenesis)
+import HSChain.Types.Merkle.Types
+
+import TM.Util.MockChain (HSChainT, withHSChainT)
+
+
+tests :: TestTree
+tests = testGroup "Coin"
+  [ runTestSet "In-memory" runInMemoty
+  , runTestSet "Dabase"    (runDatabase True)
+  , runTestSet "Dabase"    (runDatabase False)
+  ]
+
+runTestSet :: Monad m => String -> (TestT m () -> IO ()) -> TestTree
+runTestSet name run = testGroup name
+  [ testCase "Single TX"     $ run singleSpend
+  , testCase "Bad balance"   $ run badSpend
+  , testCase "Bad signature" $ run badSignature
+  , testCase "Dense  spend chain"  $ run $ spendChain  True
+  , testCase "Sparce spend chain"  $ run $ spendChain  False
+  , testCase "Dense  double spend" $ run $ doubleSpend True
+  , testCase "Sparce double spend" $ run $ doubleSpend False
+  ]
+
+singleSpend,badSpend,badSignature :: Monad m => TestT m ()
+-- Simple spending
+singleSpend = do
+  advance [ signTx sk1 TxSend { txInputs  = [ UTXO 0 (hashed dep1) ]
+                              , txOutputs = [ Unspent pk2 55
+                                            , Unspent pk3 45
+                                            ]
+                              } ]
+-- Coins are not balanced
+badSpend = do
+  bad [ signTx sk1 TxSend { txInputs  = [ UTXO 0 (hashed dep1) ]
+                          , txOutputs = [ Unspent pk2 55
+                                        , Unspent pk3 1000
+                                        ]
+                          } ]
+-- Transaction siganture is not valid
+badSignature = do
+  bad [ signTx sk2 TxSend { txInputs  = [ UTXO 0 (hashed dep1) ]
+                          , txOutputs = [ Unspent pk2 100 ]
+                          } ]
+
+-- Transfer coins between accounts. We optionally insert empty block between 
+spendChain :: Monad m => Bool -> TestT m ()
+spendChain dense = do
+  let txA = signTx sk1 TxSend { txInputs  = [ UTXO 0 (hashed dep1) ]
+                              , txOutputs = [ Unspent pk2 100 ]
+                              }
+  advance [ txA ]
+  unless dense $ advance []
+  let txB = signTx sk2 TxSend { txInputs  = [ UTXO 0 (hashed txA) ]
+                              , txOutputs = [ Unspent pk3 100 ]
+                              }
+  advance [ txB ]
+  unless dense $ advance []
+  let txC = signTx sk3 TxSend { txInputs  = [ UTXO 0 (hashed txB) ]
+                              , txOutputs = [ Unspent pk3 100 ]
+                              }
+  advance [ txC ]
+
+-- Attempt to double spend coins
+doubleSpend :: Monad m => Bool -> TestT m ()
+doubleSpend dense = do
+  let txA = signTx sk1 TxSend { txInputs  = [ UTXO 0 (hashed dep1) ]
+                              , txOutputs = [ Unspent pk2 100 ]
+                              }
+  advance [ txA ]
+  -- First spend
+  let txB = signTx sk2 TxSend { txInputs  = [ UTXO 0 (hashed txA) ]
+                              , txOutputs = [ Unspent pk3 100 ]
+                              }
+  advance [txB]
+  unless dense $ advance []
+  bad [txB]
+
+
+signTx :: PrivKey (Alg BData) -> TxSend -> Tx
+signTx k tx = Send (publicKey k) (signHashed k tx) tx
+
+----------------------------------------------------------------
+-- Monad for state tests
+----------------------------------------------------------------
+
+newtype TestT m a = TestT (ReaderT Bool (StateT (StateView m BData) m) a)
+  deriving newtype (Functor, Applicative, Monad)
+
+runInMemoty :: TestT IO a -> IO a
+runInMemoty (TestT test) = do
+  (sv0,_,_) <- inMemoryStateView valSet
+  Right sv1 <- validatePropBlock sv0 genesis valSet
+  evalStateT (runReaderT test False) sv1
+
+runDatabase :: Bool -> TestT (HSChainT BData IO) a -> IO a
+runDatabase doCommit (TestT test) = withHSChainT $ do
+  initDatabase
+  mustQueryRW $ do initCoinDB
+                   storeGenesis $ Genesis genesis valSet
+  (sv0, _)  <- databaseStateView valSet
+  Right sv1 <- validatePropBlock sv0 genesis valSet
+  evalStateT (runReaderT test doCommit) sv1
+
+-- Create new block and advance state by one step
+advance :: Monad m => [Tx] -> TestT m ()
+advance txs = mintBlock txs >>= \case
+  Left  e  -> error $ show e
+  Right () -> return ()
+
+-- Create new block which should not pass validation
+bad :: Monad m => [Tx] -> TestT m ()
+bad txs = mintBlock txs >>= \case
+  Left  _  -> return ()
+  Right () -> error "Unexpected success"
+
+mintBlock :: Monad m => [Tx] -> TestT m (Either (BChError BData) ())
+mintBlock txs = TestT $ do
+  sv <- get
+  lift (lift (validatePropBlock sv (newBlock sv) valSet)) >>= \case
+    Left  e   -> return $ Left e
+    Right sv' -> do
+      ask >>= \case
+        False -> put sv'
+        True  -> (lift . lift) (commitState sv') >>= put
+      return $ Right ()
+  where
+    -- We create new block and fill most of field with junk. State
+    -- transitions doesn't check them so there's no need to fake them
+    newBlock v = Block
+      { blockHeight        = maybe (Height 0) succ $ stateHeight v
+      , blockPrevBlockID   = Nothing
+      , blockValidators    = hashed valSet
+      , blockNewValidators = hashed valSet
+      , blockPrevCommit    = Nothing
+      , blockEvidence      = merkled []
+      , blockData          = merkled $ BData txs
+      }
+
+genesis :: Block BData
+genesis = makeGenesis (BData deposits) valSet valSet
+
+sk1,sk2,sk3 :: PrivKey   (Alg BData)
+pk1,pk2,pk3 :: PublicKey (Alg BData)
+(pk1,sk1):(pk2,sk2):(pk3,sk3):_ = map (\k -> (publicKey k, k)) $ makePrivKeyStream 1337
+
+valSet :: ValidatorSet (Alg BData)
+Right valSet = makeValidatorSet [ Validator pk1 1 ]
+
+deposits :: [Tx]
+dep1     :: Tx
+deposits@[dep1] =
+  [ Deposit pk1 100
+  ]

--- a/hschain-examples/test/TM/Util/MockChain.hs
+++ b/hschain-examples/test/TM/Util/MockChain.hs
@@ -48,6 +48,8 @@ runHSChainT c (HSChainT m) = do
   cache <- newCached
   runReaderT m (c,cache)
 
+withHSChainT :: (MonadIO m, MonadMask m) => HSChainT a m x -> m x
+withHSChainT m = withDatabase "" $ \c -> runHSChainT c m
 
 ----------------------------------------------------------------
 -- Validators for mockchain


### PR DESCRIPTION
Short: query condition in`dbLookupUTXO` was wrong so double spend transaction was provisionally accepted and consequent write crashed due to constraint violations. Also PR contains:

1. Tests for coin state transitions
2. Orphans for working with database using coin types