### PR TITLE
Extend prepared queries

### DIFF
--- a/hschain-db/HSChain/Store/Query.hs
+++ b/hschain-db/HSChain/Store/Query.hs
@@ -62,6 +62,7 @@ module HSChain.Store.Query (
   , preparedQuery
   , preparedQuery1
   , preparedQueryScanl
+  , preparedQueryScanl1
   , preparedExecute
     -- * Query transformer
   , QueryT(..)
@@ -549,6 +550,7 @@ preparedQuery (PreparedQuery stmt) p = liftQueryRO $ Query $ liftIO $ do
         Just x  -> fetchAll (xs . (x:))
   (($ []) <$> fetchAll id) `finally` SQL.reset stmt
 
+-- | Scan fetchched result with possibility of terminating early.
 preparedQueryScanl
   :: (SQL.ToRow p, SQL.FromRow q, MonadQueryRO m)
   => PreparedQuery p q          -- ^ Query
@@ -564,6 +566,25 @@ preparedQueryScanl (PreparedQuery stmt) p step b0 = liftQueryRO $ Query $ liftIO
           Nothing     -> return []
         Nothing -> return []
   fetch b0 `finally` SQL.reset stmt
+
+-- | Another variant of partial fetching of query. Last value is
+--   included into query result.
+preparedQueryScanl1
+  :: (SQL.ToRow p, SQL.FromRow q, MonadQueryRO m)
+  => PreparedQuery p q           -- ^ Query
+  -> p                           -- ^ Parameters
+  -> (q -> b -> Either a (a, b)) -- ^ Process result. This function may terminate early
+  -> b                           -- ^ Initial value
+  -> m [a]
+preparedQueryScanl1 (PreparedQuery stmt) p step b0 = liftQueryRO $ Query $ liftIO $ do
+  SQL.bind stmt p
+  let fetch b = SQL.nextRow stmt >>= \case
+        Just q  -> case step q b of
+          Right (a,b') -> (a:) <$> fetch b'
+          Left   a     -> return [a]
+        Nothing -> return []
+  fetch b0 `finally` SQL.reset stmt
+
 
 preparedQuery1 :: (SQL.ToRow p, SQL.FromRow q, MonadQueryRO m) => PreparedQuery p q -> p -> m (Maybe q)
 preparedQuery1 (PreparedQuery stmt) p = liftQueryRO $ Query $ liftIO $ do


### PR DESCRIPTION
Add ability to avoid fetching all data from prepared queries. API is in style of hybrid of unfoldr/scanl. It come in two variant one that allows to stop early and another which allows to stop early and provides last element at the same time