### PR TITLE
Allow mempool to be used at hight throughput and restore mempool stat

### DIFF
--- a/hschain-examples/HSChain/Mock/Types.hs
+++ b/hschain-examples/HSChain/Mock/Types.hs
@@ -79,6 +79,7 @@ instance Default (NetworkCfg Example) where
     , pexAskPeersDelay       = 10000
     , reconnectionRetries    = 12
     , reconnectionDelay      = 100
+    , mempoolLogInterval     = 1000
     }
 
 

--- a/hschain-examples/test/TM/Util/Network.hs
+++ b/hschain-examples/test/TM/Util/Network.hs
@@ -108,4 +108,5 @@ instance Default (NetworkCfg FastTest) where
     , pexAskPeersDelay       = 50
     , reconnectionRetries    = 12
     , reconnectionDelay      = 100
+    , mempoolLogInterval     = 10000
     }

--- a/hschain/HSChain/Internal/Types/Config.hs
+++ b/hschain/HSChain/Internal/Types/Config.hs
@@ -85,6 +85,7 @@ data NetworkCfg app = NetworkCfg
   , pexAskPeersDelay       :: !Int
   , reconnectionRetries    :: !Int -- ^ Number of retries before abandoning reconnection attempts
   , reconnectionDelay      :: !Int -- ^ Initial delay between attempting to reconnect
+  , mempoolLogInterval     :: !Int -- ^ Delay between logging mempool information
   }
   deriving (Show,Generic)
 

--- a/hschain/HSChain/P2P.hs
+++ b/hschain/HSChain/P2P.hs
@@ -30,7 +30,6 @@ import HSChain.Crypto (Hashed)
 import HSChain.Control.Util
 import HSChain.Mempool
 import HSChain.Internal.Types.Config
-import HSChain.Internal.Types.Consensus
 import HSChain.Logger
 import HSChain.Monitoring
 import HSChain.Network.Types

--- a/hschain/HSChain/P2P.hs
+++ b/hschain/HSChain/P2P.hs
@@ -28,6 +28,7 @@ import HSChain.Control.Class
 import HSChain.Control.Shepherd
 import HSChain.Crypto (Hashed)
 import HSChain.Control.Util
+import HSChain.Mempool
 import HSChain.Internal.Types.Config
 import HSChain.Internal.Types.Consensus
 import HSChain.Logger
@@ -52,7 +53,7 @@ startPeerDispatcher
   -> NetworkAPI               -- ^ API for networking
   -> [NetAddr]                -- ^ Set of initial addresses to connect
   -> AppChans n a             -- ^ Channels for communication with main application
-  -> MempoolHandle (Hashed (Alg a) (TX a)) (TX a)
+  -> Mempool m (Hashed (Alg a) (TX a)) (TX a)
   -> m ()
 startPeerDispatcher p2pCfg net addrs AppChans{..} mempool = logOnException $ do
   logger InfoS "Starting peer dispatcher" $ sl "seed" addrs

--- a/hschain/HSChain/Run.hs
+++ b/hschain/HSChain/Run.hs
@@ -23,6 +23,7 @@ module HSChain.Run (
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Catch
+import Control.Concurrent             (threadDelay)
 import Control.Concurrent.STM         (atomically)
 import Control.Concurrent.STM.TBQueue (lengthTBQueue)
 import Katip (sl)
@@ -101,7 +102,7 @@ runNode Configuration{..} NodeDescription{..} = do
                                     <> sl "discarded" mempool'discarded
                                     <> sl "filtered"  mempool'filtered
                                      )
-        waitSec 0.25
+        liftIO $ threadDelay $ 1000 * mempoolLogInterval cfgNetwork
     , forever $ do
         n <- liftIO $ atomically $ lengthTBQueue $ appChanRx appCh
         usingGauge prometheusMsgQueue n

--- a/hschain/HSChain/Run.hs
+++ b/hschain/HSChain/Run.hs
@@ -86,7 +86,7 @@ runNode Configuration{..} NodeDescription{..} = do
   return
     [ id $ descendNamespace "net"
          $ startPeerDispatcher cfgNetwork bchNetwork bchInitialPeers appCh
-           (mempoolHandle $ stateMempool st)
+           (stateMempool st)
     , id $ descendNamespace "consensus"
          $ runApplication cfgConsensus nodeValidationKey st nodeCallbacks appCh
     -- , forever $ do

--- a/notebook/hschain/logs.py
+++ b/notebook/hschain/logs.py
@@ -124,7 +124,7 @@ class Log(object):
     def mempool(self):
         "Raw mempool stats"
         df = self.df
-        mempool = df[df['ns'].apply(lambda ns: ns == ['consensus','mempool'])].drop(['ns'], axis=1).copy()
+        mempool = df[df['ns'].apply(lambda ns: ns == ['mempool'])].drop(['ns'], axis=1).copy()
         mempool['size']      = mempool['data'].apply(lambda x: x['size'])
         mempool['filtered']  = mempool['data'].apply(lambda x: x['filtered'])
         mempool['added']     = mempool['data'].apply(lambda x: x['added'])


### PR DESCRIPTION
As it turns out old mempool gossip (try to send TX every N ms) is completely unusable at high througput. So obvious solution is to try to send TX as soon as we accepted one in the mempool. Downside of new scheme is that we won't send txs that already in the mempool to freshly connected peer. But that should be handled separately.

This PR restores collection of mempool stats as well