### PR TITLE
Add method to CryptoHash type class

### DIFF
--- a/hschain-crypto/HSChain/Crypto/Classes/Hash.hs
+++ b/hschain-crypto/HSChain/Crypto/Classes/Hash.hs
@@ -112,6 +112,10 @@ class (ByteReprSized (Hash alg)) => CryptoHash alg where
   hashBlob     :: BS.ByteString -> Hash alg
   -- | Compute hash of lazy bytestring
   hashLazyBlob :: BL.ByteString -> Hash alg
+  -- | Hash output of a builder
+  hashBuilder :: Bld.Builder -> Hash alg
+  hashBuilder = hashLazyBlob
+              . Bld.toLazyByteStringWith (Bld.untrimmedStrategy 4096 4096) mempty
   -- | Name of algorithm
   hashAlgorithmName :: CryptoName alg
 


### PR DESCRIPTION
It allows to compute hash of value from supplied builder. Default implementation
is provided but more efficient implementation is thinkable