### PR TITLE
Add rest API for coin PoW node

### DIFF
--- a/hschain-PoW/HSChain/PoW/API.hs
+++ b/hschain-PoW/HSChain/PoW/API.hs
@@ -1,16 +1,18 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeOperators     #-}
+--
+{-# OPTIONS_GHC -Wno-orphans #-}
 -- |
 module HSChain.PoW.API where
 
 import Control.Monad.IO.Class
 import Servant.API
 import Servant.API.Generic
-import Servant.Server
 import Servant.Server.Generic
-import GHC.Generics (Generic)
+-- import Web.HttpApiData
 
 import HSChain.Crypto
 import HSChain.Examples.Coin
@@ -19,14 +21,17 @@ import HSChain.Store.Query
 
 
 data CoinAPI route = CoinAPI
-  { coinBalance :: route :- "balance" :> Get '[JSON] [(PublicKey Alg, Integer)]
+  { coinBalance  :: route :- "balance"   :> Get '[JSON] [(PublicKey Alg, Integer)]
+  , coinListUTXO :: route :- "list_utxo" :> Capture "pk" (PublicKey Alg) :> Get '[JSON] [UTXO]
   }
   deriving Generic
 
 coinServer :: (MonadIO m, MonadReadDB m) => CoinAPI (AsServerT m)
 coinServer = CoinAPI
-  { coinBalance = balanceEndpoint
+  { coinBalance  = balanceEndpoint
+  , coinListUTXO = listUtxoEndpoint
   }
+
 
 balanceEndpoint :: (MonadIO m, MonadReadDB m) => m [(PublicKey Alg, Integer)]
 balanceEndpoint = do
@@ -36,3 +41,21 @@ balanceEndpoint = do
     \  JOIN coin_state ON utxo_id = live_utxo \
     \ GROUP BY pk_dest"
   return [(k,i) | (ByteRepred k, i) <- rs]
+
+listUtxoEndpoint :: (MonadIO m, MonadReadDB m) => PublicKey Alg -> m [UTXO]
+listUtxoEndpoint pk = do
+  queryRO $ basicQuery
+    "SELECT n_out, tx_hash \
+    \  FROM coin_utxo \
+    \  JOIN coin_state ON utxo_id = live_utxo \
+    \ WHERE pk_dest = ?"
+    (Only (ByteRepred pk))
+
+----------------------------------------------------------------
+-- Orphans
+----------------------------------------------------------------
+
+instance CryptoAsymmetric a => FromHttpApiData (PublicKey a) where
+  parseUrlPiece s = case decodeBase58 s of
+    Nothing -> Left "Bad base58 encoding"
+    Just k  -> Right k

--- a/hschain-PoW/HSChain/PoW/API.hs
+++ b/hschain-PoW/HSChain/PoW/API.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE MultiWayIf        #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TypeOperators     #-}
 --
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -13,26 +15,73 @@ import Servant.API
 import Servant.API.Generic
 import Servant.Server.Generic
 -- import Web.HttpApiData
+import Database.SQLite.Simple            ((:.)(..))
 
+import HSChain.Control.Channels
 import HSChain.Crypto
 import HSChain.Examples.Coin
 import HSChain.Store.Query
-
+import HSChain.PoW.Mempool
 
 
 data CoinAPI route = CoinAPI
   { coinBalance  :: route :- "balance"   :> Get '[JSON] [(PublicKey Alg, Integer)]
   , coinListUTXO :: route :- "list_utxo" :> Capture "pk" (PublicKey Alg) :> Get '[JSON] [UTXO]
+  , coinMakeTx   :: route :- "make_tx"
+                          :> Capture "from" (PublicKey Alg)
+                          :> Capture "N"    Integer
+                          :> Capture "to"   (PublicKey Alg)
+                          :> Get '[JSON] (Maybe TxSend)
+  , coinPostTx   :: route :- "post_tx"
+                          :> ReqBody '[JSON] TxCoin
+                          :> Post '[PlainText] String
   }
   deriving Generic
 
-coinServer :: (MonadIO m, MonadReadDB m) => CoinAPI (AsServerT m)
-coinServer = CoinAPI
+coinServer :: (MonadIO m, MonadReadDB m) => MempoolAPI m Coin -> CoinAPI (AsServerT m)
+coinServer mempool = CoinAPI
   { coinBalance  = balanceEndpoint
   , coinListUTXO = listUtxoEndpoint
+  , coinMakeTx   = makeTxEndpoint
+  , coinPostTx   = postTxEndpoint mempool
   }
 
+postTxEndpoint
+  :: (MonadIO m, MonadReadDB m)
+  => MempoolAPI m Coin -> TxCoin -> m String
+postTxEndpoint MempoolAPI{..} tx = do
+  sinkIO postTransaction tx
+  return "TRIED"
+  
 
+makeTxEndpoint
+  :: (MonadIO m, MonadReadDB m)
+  => PublicKey Alg -> Integer -> PublicKey Alg -> m (Maybe TxSend)
+makeTxEndpoint pkFrom toSend pkTo = do
+  -- Select all UTXOs in random order
+  utxos <- queryRO $ basicQuery
+    "SELECT n_out, tx_hash, pk_dest, n_coins \
+    \  FROM coin_utxo  \
+    \  JOIN coin_state ON utxo_id = live_utxo \
+    \ WHERE pk_dest = ?"
+    (Only (ByteRepred pkFrom))
+  return $ do
+    (tot,ins) <- selectUTXO 0 utxos
+    return TxSend
+      { txInputs  = ins
+      , txOutputs = Unspent pkTo toSend
+                  : if | tot > toSend -> [Unspent pkFrom (tot - toSend)]
+                       | otherwise    -> []
+      }
+  where
+    selectUTXO acc _
+      | acc >= toSend = Just (acc,[])
+    selectUTXO _  []  = Nothing
+    selectUTXO acc ((u :. Unspent _ n):rest) = do
+      (tot,us) <- selectUTXO (acc + n) rest
+      return (tot, u:us)
+
+  
 balanceEndpoint :: (MonadIO m, MonadReadDB m) => m [(PublicKey Alg, Integer)]
 balanceEndpoint = do
   rs <- queryRO $ basicQuery_

--- a/hschain-PoW/HSChain/PoW/API.hs
+++ b/hschain-PoW/HSChain/PoW/API.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators     #-}
+-- |
+module HSChain.PoW.API where
+
+import Control.Monad.IO.Class
+import Servant.API
+import Servant.API.Generic
+import Servant.Server
+import Servant.Server.Generic
+import GHC.Generics (Generic)
+
+import HSChain.Crypto
+import HSChain.Examples.Coin
+import HSChain.Store.Query
+
+
+
+data CoinAPI route = CoinAPI
+  { coinBalance :: route :- "balance" :> Get '[JSON] [(PublicKey Alg, Integer)]
+  }
+  deriving Generic
+
+coinServer :: (MonadIO m, MonadReadDB m) => CoinAPI (AsServerT m)
+coinServer = CoinAPI
+  { coinBalance = balanceEndpoint
+  }
+
+balanceEndpoint :: (MonadIO m, MonadReadDB m) => m [(PublicKey Alg, Integer)]
+balanceEndpoint = do
+  rs <- queryRO $ basicQuery_
+    "SELECT pk_dest, SUM(n_coins) \
+    \  FROM coin_utxo \
+    \  JOIN coin_state ON utxo_id = live_utxo \
+    \ GROUP BY pk_dest"
+  return [(k,i) | (ByteRepred k, i) <- rs]

--- a/hschain-PoW/HSChain/PoW/Node.hs
+++ b/hschain-PoW/HSChain/PoW/Node.hs
@@ -58,11 +58,12 @@ import HSChain.Config
 
 -- |Node's configuration.
 data Cfg = Cfg
-  { cfgPort  :: Word16
-  , cfgPeers :: [NetAddr]
-  , cfgLog   :: [ScribeSpec]
-  , cfgMaxH  :: Maybe Height
-  , cfgDB    :: Maybe FilePath
+  { cfgPort   :: Word16
+  , cfgPeers  :: [NetAddr]
+  , cfgLog    :: [ScribeSpec]
+  , cfgMaxH   :: Maybe Height
+  , cfgDB     :: Maybe FilePath
+  , cfgWebAPI :: Maybe Int
   }
   deriving stock (Show, Generic)
   deriving (JSON.FromJSON) via SnakeCase (DropSmart (Config Cfg))

--- a/hschain-PoW/exe-test/run-pow.sh
+++ b/hschain-PoW/exe-test/run-pow.sh
@@ -4,7 +4,7 @@ trap 'echo TRAP; pkill -P $$' SIGINT SIGTERM
 
 cabal new-build hschain-PoW 
 echo ====
-export PK1='"FPY3TBv4c4gKkTsWH68wUAUrXvaLnJnWsDEwhHqotE4T"'
-export PK2='"Gt1aMuZqJ2vnVmrVvgTNsmcYg2aYfc8SbXzfaVFBzE6t"'
+export PK1=FPY3TBv4c4gKkTsWH68wUAUrXvaLnJnWsDEwhHqotE4T
+export PK2=Gt1aMuZqJ2vnVmrVvgTNsmcYg2aYfc8SbXzfaVFBzE6t
 cabal new-exec -- hschain-PoW-coin pow/node1.yaml --mine --priv-key-env-var PK1 &
 cabal new-exec -- hschain-PoW-coin pow/node2.yaml --mine --priv-key-env-var PK2

--- a/hschain-PoW/exe/coin-key.hs
+++ b/hschain-PoW/exe/coin-key.hs
@@ -2,14 +2,14 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 import Control.Monad
-import qualified Data.Aeson as JSON
 import Data.Maybe
 import Data.Yaml (decodeFileThrow)
 import Data.Map  (Map,(!))
--- import qualified Data.ByteString.Lazy as BL
+import Data.Text (Text)
+import qualified Data.Aeson                 as JSON
 import qualified Data.ByteString.Lazy.Char8 as BL8
-import qualified Data.Text as T
-import qualified Data.Map.Strict as Map
+import qualified Data.Text                  as T
+import qualified Data.Map.Strict            as Map
 import Options.Applicative
 
 import HSChain.Crypto
@@ -48,7 +48,7 @@ parserSign = helper <*> do
                      <> metavar "PATH"
                       )
   pure $ do
-    keymap :: Map String T.Text <- decodeFileThrow keyring
+    keymap :: Map Text Text <- decodeFileThrow keyring
     let Just (sk :: PrivKey Alg) = decodeBase58 $ keymap ! key
     mtx <- case path of
             "-" -> JSON.decode <$> BL8.getContents
@@ -71,7 +71,7 @@ parserPK = helper <*> do
                         <> metavar "KEY"
                          )
   pure $ do
-    keymap :: Map String T.Text <- decodeFileThrow keyring
+    keymap :: Map Text Text <- decodeFileThrow keyring
     forM_ keyList $ \k -> do
       case decodeBase58 =<< Map.lookup k keymap of
         Nothing -> return ()

--- a/hschain-PoW/exe/coin-key.hs
+++ b/hschain-PoW/exe/coin-key.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE ApplicativeDo       #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+import Control.Monad
+import qualified Data.Aeson as JSON
+import Data.Maybe
+import Data.Yaml (decodeFileThrow)
+import Data.Map  (Map,(!))
+-- import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Lazy.Char8 as BL8
+import qualified Data.Text as T
+import qualified Data.Map.Strict as Map
+import Options.Applicative
+
+import HSChain.Crypto
+import HSChain.Examples.Coin (Alg,signTX)
+
+main :: IO ()
+main = do
+  act <- customExecParser (prefs showHelpOnError)
+       $ info (helper <*> parser)
+         (  fullDesc
+         <> header   "Program for working with keys for coin node"
+         <> progDesc ""
+         )
+  act
+
+
+parser :: Parser (IO ())
+parser = subparser
+  ( command "gen"  (parserGen  `info` header "Generate key(s)")
+ <> command "pk"   (parserPK   `info` header "Compute public key")
+ <> command "sign" (parserSign `info` header "Sign transaction")
+  )
+
+-- Sign transaction
+parserSign :: Parser (IO ())
+parserSign = helper <*> do
+  keyring <- strOption ( short 'k'
+                      <> long  "keyring"
+                      <> help  "Keyring file"
+                      <> metavar "FILE"
+                       )
+  key  <- strArgument ( help    "key handle"
+                     <> metavar "KEY"
+                      )
+  path <- strArgument ( help    "File with TX"
+                     <> metavar "PATH"
+                      )
+  pure $ do
+    keymap :: Map String T.Text <- decodeFileThrow keyring
+    let Just (sk :: PrivKey Alg) = decodeBase58 $ keymap ! key
+    mtx <- case path of
+            "-" -> JSON.decode <$> BL8.getContents
+            _   -> JSON.decodeFileStrict path
+    case mtx of
+      Nothing -> error "Cannot decode transaction"
+      Just tx -> BL8.putStrLn . JSON.encode . signTX sk $ tx
+
+
+-- Print public key
+parserPK :: Parser (IO ())
+parserPK = helper <*> do
+  keyring <- strOption ( short 'k'
+                      <> long  "keyring"
+                      <> help  "Keyring file"
+                      <> metavar "FILE"
+                       )
+  keyList <- many
+           $ strArgument ( help    "List of key handles"
+                        <> metavar "KEY"
+                         )
+  pure $ do
+    keymap :: Map String T.Text <- decodeFileThrow keyring
+    forM_ keyList $ \k -> do
+      case decodeBase58 =<< Map.lookup k keymap of
+        Nothing -> return ()
+        Just sk -> putStrLn $ T.unpack $ encodeBase58 $ publicKey @Alg sk
+
+-- Generate fresh private keys
+parserGen :: Parser (IO ())
+parserGen = helper <*> do
+  n <- fmap (fromMaybe 1)
+     $ optional
+     $ argument auto
+     $ ( help "Number of keys"
+      <> metavar "N" 
+       )
+  pure $ act n
+  where
+    act n = replicateM_ n $ do
+      putStrLn . T.unpack . encodeBase58 =<< generatePrivKey @Alg
+

--- a/hschain-PoW/exe/coin-node.hs
+++ b/hschain-PoW/exe/coin-node.hs
@@ -23,6 +23,7 @@ import Control.Monad.Reader
 import Control.Monad.Trans.Cont
 import Data.Maybe
 import Data.List (unfoldr)
+import qualified Data.Text       as T
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
 import qualified Data.Vector     as V
@@ -73,7 +74,7 @@ main = do
               <> progDesc ""
               )
   Cfg{..} <- loadYamlSettings cmdConfigPath [] requireEnv
-  nodePrivK <- read <$> getEnv optPrivVar
+  Just nodePrivK <- decodeBase58 . T.pack <$> getEnv optPrivVar
   -- Acquire resources
   let net    = newNetworkTcp cfgPort
       netcfg = NetCfg { nKnownPeers     = 3

--- a/hschain-PoW/exe/coin-node.hs
+++ b/hschain-PoW/exe/coin-node.hs
@@ -97,9 +97,9 @@ main = do
       -- Start web node
       forM_ cfgWebAPI $ \port -> do
         dict <- lift $ CoinT ask
-        let run :: CoinT Handler a -> Handler a
-            run (CoinT m) = runReaderT m dict
-        cforkLinkedIO $ Warp.run port $ genericServeT run coinServer
+        let run :: CoinT IO a -> Handler a
+            run (CoinT m) = liftIO $ runReaderT m dict
+        cforkLinkedIO $ Warp.run port $ genericServeT run $ coinServer (mempoolAPI pow)
       -- Mining and TX generation
       when optGenerate $ do
         cforkLinked $ txGeneratorLoop pow (nodePrivK : take 100 (makePrivKeyStream 1433))

--- a/hschain-PoW/hschain-PoW.cabal
+++ b/hschain-PoW/hschain-PoW.cabal
@@ -56,6 +56,9 @@ Library
                      , vector
                      , unordered-containers >=0.2.5.0
                      , yaml
+                     -- Web stuff
+                     , servant         >=0.16 && <0.17
+                     , servant-server  >=0.16 && <0.17
   Exposed-modules:
                 HSChain.PoW.BlockIndex
                 HSChain.PoW.Types
@@ -74,7 +77,8 @@ Library
                 HSChain.PoW.P2P.Handler.Peer
                 HSChain.PoW.P2P.Handler.PEX
                 HSChain.PoW.P2P.STM.PeerRegistry
-                HSChain.PoW.P2P.STM.NonceSet                
+                HSChain.PoW.P2P.STM.NonceSet
+                HSChain.PoW.API
 
 
 Executable hschain-PoW-node
@@ -127,6 +131,10 @@ Executable hschain-PoW-coin
                      , transformers
                      , optparse-applicative
                      , yaml
+                     --
+                     , servant
+                     , servant-server
+                     , warp
   hs-source-dirs:      exe
   Main-is:             coin-node.hs
 
@@ -158,7 +166,7 @@ Test-suite hschain-PoW-tests
                      , stm
                      , tasty             >=0.11
                      , tasty-quickcheck
-                     , tasty-hunit       >=0.10                      
+                     , tasty-hunit       >=0.10
   hs-source-dirs:      test
   Main-is:             Main.hs
   Other-modules:       TM.Consensus

--- a/hschain-PoW/hschain-PoW.cabal
+++ b/hschain-PoW/hschain-PoW.cabal
@@ -117,6 +117,7 @@ Executable hschain-PoW-coin
                      , aeson
                      , katip
                      , mtl
+                     , text
                      , bytestring
                      , containers
                      , vector

--- a/hschain-PoW/hschain-PoW.cabal
+++ b/hschain-PoW/hschain-PoW.cabal
@@ -138,6 +138,25 @@ Executable hschain-PoW-coin
   hs-source-dirs:      exe
   Main-is:             coin-node.hs
 
+Executable hschain-PoW-key
+  Ghc-options:         -Wall -threaded -rtsopts "-with-rtsopts=-N -T -qn1 -A64M"
+  Default-Language:    Haskell2010
+  Build-Depends:       base                 >=4.9 && <5
+                     , hschain-PoW
+                     , hschain-merkle
+                     , hschain-types
+                     , hschain-crypto
+                     , aeson
+                     , mtl
+                     , text
+                     , bytestring
+                     , containers
+                     , vector
+                     , yaml
+                     , optparse-applicative
+  hs-source-dirs:      exe
+  Main-is:             coin-key.hs
+
 
 -- Test suite
 Test-suite hschain-PoW-tests


### PR DESCRIPTION
This PR adds basic API which allows to query node over HTTP for following:

 - Ask balances of keys
 - Ask to generate unsigned transaction 
 - Post signed transaction 

It add program for working with keys and signing transactions. Keys are stored in plain text in the yaml file. Not terribly secure but suitable for testing when one have to work with multiple keys at once