### PR TITLE
Report errors processing of mined's block state

### DIFF
--- a/hschain-PoW/HSChain/PoW/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/Consensus.hs
@@ -353,7 +353,7 @@ processBlock
   :: (BlockData b, MonadIO m, MonadLogger m)
   => BlockDB m b
   -> Block b
-  -> ExceptT (BlockError b) (StateT (Consensus m b) m) ()
+  -> ExceptT (BlockError b) (StateT (Consensus m b) m) [(BlockID b, BlockException b)]
 processBlock db block = do
   use (blockIndex . to (lookupIdx bid)) >>= \case
     Just _  -> return ()
@@ -407,9 +407,9 @@ invalidateBlock bid = do
 
 -- | Find best reachable candidate block.
 bestCandidate
-  :: (BlockData b, Monad m)
+  :: (BlockData b, MonadLogger m)
   => BlockDB m b
-  -> ExceptT (BlockError b) (StateT (Consensus m b) m) ()
+  -> ExceptT (BlockError b) (StateT (Consensus m b) m) [(BlockID b, BlockException b)]
 bestCandidate db = do
   bestWork <- use $ bestHead . _1 . to bhWork
   missing  <- use requiredBlocks
@@ -418,7 +418,7 @@ bestCandidate db = do
                                        >>> sortOn (Down . bhWork)
                                         )
   case heads of
-    []  -> cleanCandidates
+    []  -> [] <$ cleanCandidates
     h:_ -> do
       bIdx        <- use blockIndex
       (best,st,_) <- use bestHead
@@ -428,14 +428,18 @@ bestCandidate db = do
               Nothing -> error "CANT retrieveBlock"
               Just b  -> return b
             lift (applyBlock s bIdx bh block) >>= \case
-              Left  _ -> throwError (bhBID bh)
+              Left  e -> do logger DebugS "Block apply failed" ( sl "bid" (bhBID bh)
+                                                              <> sl "err" e)
+                            throwError (bhBID bh, e)
               Right b -> return b
       state' <- lift $ lift
               $ runExceptT
               $ traverseBlockIndexM rollback update best h st
       case state' of
-        Left  bid -> invalidateBlock bid >> bestCandidate db
-        Right s   -> bestHead .= (h,s,makeLocator h) >> cleanCandidates
+        Left  (bid,e) -> do invalidateBlock bid
+                            ((bid,e) :) <$> bestCandidate db
+        Right s       -> do bestHead .= (h,s,makeLocator h) >> cleanCandidates
+                            pure []
   where
     findBest missing Head{..} =
       case Seq.takeWhileL (\b -> bhBID b `Set.notMember` missing) bchMissing of
@@ -481,4 +485,3 @@ createConsensus db sView bIdx = do
              Just b  -> b
              Nothing -> error "Internal error: state's BID is not in index"
   execStateT (runExceptT (bestCandidate db)) c0
-  where

--- a/hschain-PoW/test/TM/Consensus.hs
+++ b/hschain-PoW/test/TM/Consensus.hs
@@ -310,7 +310,7 @@ runTest msgList = runNoLogsT $ do
                        [ "  >> "++show (hash b :: Hash SHA256) ++ " => "++show b
                        | b <- [genesis, block1, block2, block3, block2', block3', block4']
                        ]
-    toE   = either Just (\() -> Nothing)
+    toE   = either Just (\_ -> Nothing)
     run s = flip runStateT s . runExceptT
     --
     loop _  _ []     = return ()


### PR DESCRIPTION
Propagate errors in mined block's state. This is very useful for testing and debugging of mining algorithms

Also make logging slightly more informative