### PR TITLE
Rework merkle trees

### DIFF
--- a/hschain-merkle/HSChain/Types/Merkle/Tree.hs
+++ b/hschain-merkle/HSChain/Types/Merkle/Tree.hs
@@ -8,21 +8,18 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
 module HSChain.Types.Merkle.Tree
-  ( -- * Tree data types
-    MerkleBlockTree(..)
-  , merkleBlockTreeHash
-    -- * Building tree
+  ( -- * Type class for Merkle trees
+    MerkleTree(..)
+    -- * Tree data types
+  , MerkleBlockTree(..)
   , createMerkleTree
-    -- * Check tree
-  , isBalanced
-    -- * Merkle proof
+  , MerkleBlockTree1(..)
+  , createMerkleTree1
+  , Node(..)
   , MerkleProof(..)
-  , checkMerkleProof
-  , createMerkleProof
   ) where
 
 import Control.Applicative
-import Control.Category ((>>>))
 import Control.Monad
 import Data.Bits
 import Data.Function
@@ -34,31 +31,87 @@ import HSChain.Types.Merkle.Types
 
 
 ----------------------------------------------------------------
--- Data types
+-- Type class
 ----------------------------------------------------------------
 
--- | Balanced binary Merkle tree. Constructors in this module generate
---   balanced binary tree.
-newtype MerkleBlockTree f alg a = MerkleBlockTree
-  { merkleBlockTree :: MerkleNode f alg (Maybe (Node f alg a))
+-- | Type class for various Merkle trees. It provides generic API for
+--   the proofs of inclusion.
+class CryptoHashable a => MerkleTree t a where
+  type Proof t :: * -> * -> *
+  -- | Obtain root hash of the tree.
+  rootHash :: t alg f a -> Hash alg
+  -- | Create proof-of-inclusion for element of Merkle tree.
+  createMerkleProof :: t alg Identity a -> a -> Maybe (Proof t alg a)
+  -- | Verify that proof is indeed correct.
+  verifyMerkleProof :: CryptoHash alg => t alg f a -> Proof t alg a -> Bool
+  -- | Check that Merkle tree satisfy internal invariants
+  checkMerkleInvariants :: t alg Identity a -> Bool
+
+
+----------------------------------------------------------------
+-- Concrete trees
+----------------------------------------------------------------
+
+-- | Balanced binary Merkle tree.
+newtype MerkleBlockTree alg f a = MerkleBlockTree
+  { merkleBlockTree :: MerkleNode f alg (Maybe (Node alg f a))
   }
   deriving (Show, Foldable, Generic)
 
-merkleBlockTreeHash :: MerkleBlockTree f alg a -> Hash alg
-merkleBlockTreeHash = merkleHash . merkleBlockTree
+-- | Nonempty balanced binary Merkle tree.
+newtype MerkleBlockTree1 alg f a = MerkleBlockTree1
+  { merkleBlockTree1 :: MerkleNode f alg (Node alg f a)
+  }
+  deriving (Show, Foldable, Generic)
 
 -- | Single node of tree
-data Node f alg a
-  = Branch (MerkleNode f alg (Node f alg a))
-           (MerkleNode f alg (Node f alg a))
+data Node alg f a
+  = Branch (MerkleNode f alg (Node alg f a))
+           (MerkleNode f alg (Node alg f a))
   | Leaf   !a
   deriving (Show, Foldable, Generic)
 
+-- | Compact proof of inclusion of value in Merkle tree.
+data MerkleProof alg a = MerkleProof
+  { merkleProofLeaf :: !a
+  , merkleProofPath :: [Either (Hash alg) (Hash alg)]
+  }
+  deriving (Show, Eq, Generic)
 
-instance (CryptoHash alg) => CryptoHashable (MerkleBlockTree f alg a) where
+instance (CryptoHashable a, Eq a) => MerkleTree MerkleBlockTree a where
+  type Proof MerkleBlockTree = MerkleProof
+  rootHash = merkleHash . merkleBlockTree
+  --
+  createMerkleProof (MerkleBlockTree mtree) a = do
+    path <- searchBinTree a =<< merkleValue mtree
+    return $ MerkleProof a path
+  --
+  verifyMerkleProof t p = rootHash t == hash (Just (calcRootNode p))
+  --
+  checkMerkleInvariants = maybe True isBalanced . merkleValue . merkleBlockTree
+
+
+instance (CryptoHashable a, Eq a) => MerkleTree MerkleBlockTree1 a where
+  type Proof MerkleBlockTree1 = MerkleProof
+  rootHash = merkleHash . merkleBlockTree1
+  --
+  createMerkleProof (MerkleBlockTree1 mtree) a = do
+    path <- searchBinTree a $ merkleValue mtree
+    return $ MerkleProof a path
+  --
+  verifyMerkleProof t p = rootHash t == hash (calcRootNode p)
+  --
+  checkMerkleInvariants = isBalanced . merkleValue . merkleBlockTree1
+
+
+
+instance (CryptoHash alg) => CryptoHashable (MerkleBlockTree alg f a) where
   hashStep = hashStep . merkleBlockTree
 
-instance (CryptoHash alg, CryptoHashable a) => CryptoHashable (Node f alg a) where
+instance (CryptoHash alg) => CryptoHashable (MerkleBlockTree1 alg f a) where
+  hashStep = hashStep . merkleBlockTree1
+
+instance (CryptoHash alg, CryptoHashable a) => CryptoHashable (Node alg f a) where
   hashStep node
     = hashStep (UserType "hschain" "Merkle.Tree.Node")
    <> case node of
@@ -67,7 +120,7 @@ instance (CryptoHash alg, CryptoHashable a) => CryptoHashable (Node f alg a) whe
                    <> hashStep b
         Leaf   a   -> hashStep (ConstructorIdx 1)
                    <> hashStep a
-                           
+
 
 
 ----------------------------------------------------------------
@@ -112,7 +165,7 @@ nextPow2 n = 1 `shiftL` (finiteBitSize n - countLeadingZeros n)
 createMerkleTree
   :: (CryptoHash alg, CryptoHashable a, IsMerkle f)
   => [a]                        -- ^ Leaves of tree
-  -> MerkleBlockTree f alg a
+  -> MerkleBlockTree alg f a
 createMerkleTree leaves
   = MerkleBlockTree
   $ merkled
@@ -120,48 +173,45 @@ createMerkleTree leaves
       [] -> Nothing
       _  -> Just $ buildMerkleTree (Branch `on` merkled) $ Leaf <$> leaves
 
+-- | Create perfectly balanced Merkle tree. In order to make
+--   construction deterministic (there are many perfectly balanced
+--   binary trees is number of leaves is not power of two) depth of
+--   leaves is nonincreasing.
+createMerkleTree1
+  :: (CryptoHash alg, CryptoHashable a, IsMerkle f)
+  => [a]                        -- ^ Leaves of tree
+  -> Maybe (MerkleBlockTree1 alg f a)
+createMerkleTree1 []     = Nothing
+createMerkleTree1 leaves = Just
+  $ MerkleBlockTree1
+  $ merkled
+  $ buildMerkleTree (Branch `on` merkled) $ Leaf <$> leaves
+
 
 ----------------------------------------------------------------
 -- Merkle Proof
 ----------------------------------------------------------------
 
--- | Compact proof of inclusion of value in Merkle tree.
-data MerkleProof alg a = MerkleProof
-  { merkleProofLeaf :: !a
-  , merkleProofPath :: [Either (Hash alg) (Hash alg)]
-  }
-  deriving (Show, Eq, Generic)
-
 -- | Check proof of inclusion
-checkMerkleProof
+calcRootNode
   :: forall alg a. (CryptoHashable a, CryptoHash alg)
-  => Hash alg          -- ^ Root hash of Merkle Tree
-  -> MerkleProof alg a -- ^ Proof
-  -> Bool
-checkMerkleProof rootH (MerkleProof a path)
-  = rootH == calcH
+  => MerkleProof alg a -- ^ Proof
+  -> Node alg Proxy a
+calcRootNode (MerkleProof a path)
+  = foldr step (Leaf a) path
   where
-    calcH = hash
-          $ Just
-          $ foldr step (Leaf a) path
-    step :: Either (Hash alg) (Hash alg) -> Node Proxy alg a -> Node Proxy alg a
+    step :: Either (Hash alg) (Hash alg) -> Node alg Proxy a -> Node alg Proxy a
     step (Left  g) h = Branch (fromHashed (hashed h)) (fromHashed $ Hashed g)
     step (Right g) h = Branch (fromHashed (Hashed g)) (fromHashed $ hashed h)
 
-
--- | Create proof of inclusion. Implementation is rather inefficient
-createMerkleProof
+searchBinTree
   :: (Eq a)
-  => MerkleBlockTree Identity alg a
-  -> a
-  -> Maybe (MerkleProof alg a)
-createMerkleProof (MerkleBlockTree mtree) a = do
-  path <- search =<< merkleValue mtree
-  return $ MerkleProof a path
+  => a -> Node alg Identity a -> Maybe [Either (Hash alg) (Hash alg)]
+searchBinTree a = go
   where
-    search (Leaf   b)   = [] <$ guard (a == b)
-    search (Branch b c) =  (Left  (merkleHash c):) <$> search (merkleValue b)
-                       <|> (Right (merkleHash b):) <$> search (merkleValue c)
+    go (Leaf   b)   = [] <$ guard (a == b)
+    go (Branch b c) =  (Left  (merkleHash c):) <$> go (merkleValue b)
+                   <|> (Right (merkleHash b):) <$> go (merkleValue c)
 
 
 
@@ -172,11 +222,9 @@ createMerkleProof (MerkleBlockTree mtree) a = do
 
 -- | Check whether Merkle tree is balanced and in canonical form:
 --   depth of leaves does not decrease.
-isBalanced :: MerkleBlockTree Identity alg a -> Bool
-isBalanced =
-  merkleBlockTree >>> merkleValue >>> \case
-    Nothing   -> True
-    Just tree -> isCanonical $ calcDepth (0::Int) tree []
+isBalanced :: Node alg Identity a -> Bool
+isBalanced tree
+  = isCanonical $ calcDepth (0::Int) tree []
   where
     -- Check that node depths are nonincreasing and don't differ more
     -- that 1 from first one (tree is balanced)

--- a/hschain-merkle/test/TM/MerkleBlock.hs
+++ b/hschain-merkle/test/TM/MerkleBlock.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings    #-}
 module TM.MerkleBlock where
 
+import Data.Maybe
 import Test.Tasty
 import Test.Tasty.QuickCheck
 import HSChain.Crypto.SHA (SHA512)
@@ -15,6 +16,7 @@ import HSChain.Types.Merkle.Types
 tests :: TestTree
 tests = testGroup "Binary Merkle tree"
   [ testProperty "createMerkleTree"  prop_MerkleBlockTree
+  , testProperty "createMerkleTree1" prop_MerkleBlockTree1
   , testProperty "IdNode & Hashed"   prop_computeMerkleHashed
   , testProperty "IdNode & OptNode"  prop_computeMerkleOpt
   , testProperty "Merkle proof of inclusion is correct" prop_MerkleProofCorrect
@@ -23,36 +25,58 @@ tests = testGroup "Binary Merkle tree"
 -- Tree is balanced and all hashes are internally consistent
 prop_MerkleBlockTree :: [Integer] -> Bool
 prop_MerkleBlockTree leaves
-  = isBalanced tree
+  = checkMerkleInvariants tree
   where
-    tree :: MerkleBlockTree Identity SHA512 Integer
+    tree :: MerkleBlockTree SHA512 Identity Integer
     tree = createMerkleTree leaves
+
+-- Tree is balanced and all hashes are internally consistent
+prop_MerkleBlockTree1 :: [Integer] -> Bool
+prop_MerkleBlockTree1 leaves =
+  case leaves of
+    [] -> isNothing tree
+    _  -> maybe False checkMerkleInvariants tree
+  where
+    tree :: Maybe (MerkleBlockTree1 SHA512 Identity Integer)
+    tree = createMerkleTree1 leaves
 
 -- Computation with different wrappers give same result
 prop_computeMerkleOpt :: [Integer] -> Bool
 prop_computeMerkleOpt leaves
-  = merkleBlockTreeHash t1 == merkleBlockTreeHash t2
+  = rootHash t1 == rootHash t2
   where
-    t1 = createMerkleTree leaves :: MerkleBlockTree Identity SHA512 Integer
-    t2 = createMerkleTree leaves :: MerkleBlockTree Maybe    SHA512 Integer
+    t1 = createMerkleTree leaves :: MerkleBlockTree SHA512 Identity Integer
+    t2 = createMerkleTree leaves :: MerkleBlockTree SHA512 Maybe    Integer
 
 -- Computation with different wrappers give same result
 prop_computeMerkleHashed :: [Integer] -> Bool
 prop_computeMerkleHashed leaves
-  = merkleBlockTreeHash t1 == merkleBlockTreeHash t2
+  = rootHash t1 == rootHash t2
   where
-    t1 = createMerkleTree leaves :: MerkleBlockTree Identity SHA512 Integer
-    t2 = createMerkleTree leaves :: MerkleBlockTree Maybe    SHA512 Integer
+    t1 = createMerkleTree leaves :: MerkleBlockTree SHA512 Identity Integer
+    t2 = createMerkleTree leaves :: MerkleBlockTree SHA512 Proxy    Integer
 
   
 -- Check that merkle proofs are correct
 prop_MerkleProofCorrect :: [Integer] -> Property
 prop_MerkleProofCorrect leaves
   = property
-  $ and [ maybe False (checkMerkleProof (merkleBlockTreeHash tree)) p
+  $ and [ maybe False (verifyMerkleProof tree) p
         | p <- proofs
         ]
   where
-    tree :: MerkleBlockTree Identity SHA512 Integer
+    tree :: MerkleBlockTree SHA512 Identity Integer
     tree   = createMerkleTree leaves
+    proofs = createMerkleProof tree <$> leaves
+
+-- Check that merkle proofs are correct
+prop_MerkleProofCorrect1 :: [Integer] -> Property
+prop_MerkleProofCorrect1 leaves
+  = not (null leaves)
+  ==> and [ maybe False (verifyMerkleProof tree) p
+          | p <- proofs
+          ]
+  where
+    tree :: MerkleBlockTree1 SHA512 Identity Integer
+    Just tree = createMerkleTree1 leaves
     proofs = createMerkleProof tree <$> leaves

--- a/hschain-merkle/test/TM/MerkleBlock.hs
+++ b/hschain-merkle/test/TM/MerkleBlock.hs
@@ -15,29 +15,29 @@ import HSChain.Types.Merkle.Types
 -- | Merkle tree tests
 tests :: TestTree
 tests = testGroup "Binary Merkle tree"
-  [ testProperty "createMerkleTree"  prop_MerkleBlockTree
-  , testProperty "createMerkleTree1" prop_MerkleBlockTree1
+  [ testProperty "createMerkleTree"  prop_MerkleBinTree
+  , testProperty "createMerkleTree1" prop_MerkleBinTree1
   , testProperty "IdNode & Hashed"   prop_computeMerkleHashed
   , testProperty "IdNode & OptNode"  prop_computeMerkleOpt
   , testProperty "Merkle proof of inclusion is correct" prop_MerkleProofCorrect
   ]
 
 -- Tree is balanced and all hashes are internally consistent
-prop_MerkleBlockTree :: [Integer] -> Bool
-prop_MerkleBlockTree leaves
+prop_MerkleBinTree :: [Integer] -> Bool
+prop_MerkleBinTree leaves
   = checkMerkleInvariants tree
   where
-    tree :: MerkleBlockTree SHA512 Identity Integer
+    tree :: MerkleBinTree SHA512 Identity Integer
     tree = createMerkleTree leaves
 
 -- Tree is balanced and all hashes are internally consistent
-prop_MerkleBlockTree1 :: [Integer] -> Bool
-prop_MerkleBlockTree1 leaves =
+prop_MerkleBinTree1 :: [Integer] -> Bool
+prop_MerkleBinTree1 leaves =
   case leaves of
     [] -> isNothing tree
     _  -> maybe False checkMerkleInvariants tree
   where
-    tree :: Maybe (MerkleBlockTree1 SHA512 Identity Integer)
+    tree :: Maybe (MerkleBinTree1 SHA512 Identity Integer)
     tree = createMerkleTree1 leaves
 
 -- Computation with different wrappers give same result
@@ -45,16 +45,16 @@ prop_computeMerkleOpt :: [Integer] -> Bool
 prop_computeMerkleOpt leaves
   = rootHash t1 == rootHash t2
   where
-    t1 = createMerkleTree leaves :: MerkleBlockTree SHA512 Identity Integer
-    t2 = createMerkleTree leaves :: MerkleBlockTree SHA512 Maybe    Integer
+    t1 = createMerkleTree leaves :: MerkleBinTree SHA512 Identity Integer
+    t2 = createMerkleTree leaves :: MerkleBinTree SHA512 Maybe    Integer
 
 -- Computation with different wrappers give same result
 prop_computeMerkleHashed :: [Integer] -> Bool
 prop_computeMerkleHashed leaves
   = rootHash t1 == rootHash t2
   where
-    t1 = createMerkleTree leaves :: MerkleBlockTree SHA512 Identity Integer
-    t2 = createMerkleTree leaves :: MerkleBlockTree SHA512 Proxy    Integer
+    t1 = createMerkleTree leaves :: MerkleBinTree SHA512 Identity Integer
+    t2 = createMerkleTree leaves :: MerkleBinTree SHA512 Proxy    Integer
 
   
 -- Check that merkle proofs are correct
@@ -65,7 +65,7 @@ prop_MerkleProofCorrect leaves
         | p <- proofs
         ]
   where
-    tree :: MerkleBlockTree SHA512 Identity Integer
+    tree :: MerkleBinTree SHA512 Identity Integer
     tree   = createMerkleTree leaves
     proofs = createMerkleProof tree <$> leaves
 
@@ -77,6 +77,6 @@ prop_MerkleProofCorrect1 leaves
           | p <- proofs
           ]
   where
-    tree :: MerkleBlockTree1 SHA512 Identity Integer
+    tree :: MerkleBinTree1 SHA512 Identity Integer
     Just tree = createMerkleTree1 leaves
     proofs = createMerkleProof tree <$> leaves


### PR DESCRIPTION
- Add type class as generic API for working with proofs of inclusion
- Add nonempty tree variant
- Add serialie instaces
- Rename BlockTree -> BinTree