### PR TITLE
Implement light node

### DIFF
--- a/hschain-PoW/HSChain/Examples/Coin.hs
+++ b/hschain-PoW/HSChain/Examples/Coin.hs
@@ -591,7 +591,8 @@ coinStateView genesis = do
   st   <- mustQueryRW $ initializeStateView genesis bIdx
   return (db, bIdx, st)
   where
-    db = BlockDB { storeBlock         = storeCoinBlock
+    db = BlockDB { storeHeader        = storeCoinHeader
+                 , storeBlock         = storeCoinBlock
                  , retrieveBlock      = retrieveCoinBlock
                  , retrieveHeader     = retrieveCoinHeader
                  , retrieveAllHeaders = retrieveAllCoinHeaders
@@ -635,7 +636,7 @@ initCoinDB = mustQueryRW $ do
     \  , time       INTEGER NUT NULL \
     \  , prev       BLOB NULL \
     \  , dataHash   BLOB NOT NULL \
-    \  , blockData  BLOB NOT NULL \
+    \  , blockData  BLOB NULL \
     \  , target     BLOB NOT NULL \
     \  , nonce      INTEGER NOT NULL \
     \)"
@@ -687,7 +688,8 @@ initCoinDB = mustQueryRW $ do
 retrieveCoinBlock :: (MonadIO m, MonadReadDB m) => BlockID Coin -> m (Maybe (Block Coin))
 retrieveCoinBlock bid = queryRO $ basicQueryWith1
   coinBlockDecoder
-  "SELECT height, time, prev, blockData, target, nonce FROM coin_blocks WHERE bid = ?"
+  "SELECT height, time, prev, blockData, target, nonce FROM coin_blocks \
+  \ WHERE bid = ? AND blockData IS NOT NULL"
   (Only bid)
 
 retrieveCoinHeader :: (MonadIO m, MonadReadDB m) => BlockID Coin -> m (Maybe (Header Coin))
@@ -701,19 +703,38 @@ retrieveAllCoinHeaders = queryRO $ basicQueryWith_
   coinHeaderDecoder
   "SELECT height, time, prev, dataHash, target, nonce FROM coin_blocks ORDER BY height"
 
-storeCoinBlock :: (MonadThrow m, MonadIO m, MonadDB m) => Block Coin -> m ()
-storeCoinBlock b@Block{blockData=Coin{..}, ..} = mustQueryRW $ do
+storeCoinHeader :: (MonadThrow m, MonadIO m, MonadDB m) => Header Coin -> m ()
+storeCoinHeader b@Block{blockData=Coin{..}, ..} = mustQueryRW $ do
   basicExecute
-    "INSERT OR IGNORE INTO coin_blocks VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, ?)"
+    "INSERT OR IGNORE INTO coin_blocks VALUES (NULL, ?, ?, ?, ?, ?, NULL, ?, ?)"
     ( blockID b
     , blockHeight
     , blockTime
     , prevBlock
     , ByteRepred $ merkleHash coinData
-    , CBORed coinData
     , CBORed coinTarget
     , coinNonce
     )
+
+storeCoinBlock :: (MonadThrow m, MonadIO m, MonadDB m) => Block Coin -> m ()
+storeCoinBlock b@Block{blockData=Coin{..}, ..} = mustQueryRW $ do
+  exists <- basicQuery "SELECT blockData IS NULL FROM coin_blocks WHERE bid = ?" (Only (blockID b))
+  case exists of
+    [] -> basicExecute
+      "INSERT OR IGNORE INTO coin_blocks VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, ?)"
+      ( blockID b
+      , blockHeight
+      , blockTime
+      , prevBlock
+      , ByteRepred $ merkleHash coinData
+      , CBORed coinData
+      , CBORed coinTarget
+      , coinNonce
+      )
+    [Only True] -> basicExecute
+      "UPDATE coin_blocks SET blockData = ? WHERE bid = ?"
+      (CBORed coinData, blockID b)
+    _ -> return ()
 
 retrieveCurrentStateBlock :: MonadQueryRO m => m (Maybe (BlockID Coin))
 retrieveCurrentStateBlock = fmap fromOnly <$> basicQuery1

--- a/hschain-PoW/HSChain/Examples/Coin.hs
+++ b/hschain-PoW/HSChain/Examples/Coin.hs
@@ -587,16 +587,18 @@ coinStateView
 coinStateView genesis = do
   initCoinDB
   storeCoinBlock genesis
-  bIdx <- buildBlockIndex db
+  bIdx <- buildBlockIndex coinDB
   st   <- mustQueryRW $ initializeStateView genesis bIdx
-  return (db, bIdx, st)
-  where
-    db = BlockDB { storeHeader        = storeCoinHeader
-                 , storeBlock         = storeCoinBlock
-                 , retrieveBlock      = retrieveCoinBlock
-                 , retrieveHeader     = retrieveCoinHeader
-                 , retrieveAllHeaders = retrieveAllCoinHeaders
-                 }
+  return (coinDB, bIdx, st)
+
+coinDB :: (MonadThrow m, MonadDB m, MonadIO m) => BlockDB m Coin
+coinDB = BlockDB
+  { storeHeader        = storeCoinHeader
+  , storeBlock         = storeCoinBlock
+  , retrieveBlock      = retrieveCoinBlock
+  , retrieveHeader     = retrieveCoinHeader
+  , retrieveAllHeaders = retrieveAllCoinHeaders
+  }
 
 
 initializeStateView

--- a/hschain-PoW/HSChain/Examples/Coin.hs
+++ b/hschain-PoW/HSChain/Examples/Coin.hs
@@ -487,7 +487,7 @@ data CoinState (m :: * -> *) = CoinState
 instance (MonadDB m, MonadThrow m, MonadIO m) => StateView (CoinState m) where
   type BlockType (CoinState m) = Coin
   type MonadOf   (CoinState m) = m
-  stateBID = bhBID . overlayTip . csOverlay
+  stateBH = overlayTip . csOverlay
   ----------------
   applyBlock CoinState{..} bIdx bh b = runExceptT $ do
     -- Consistency checks

--- a/hschain-PoW/HSChain/Examples/Simple.hs
+++ b/hschain-PoW/HSChain/Examples/Simple.hs
@@ -96,6 +96,7 @@ instance MerkleMap (KV cfg) where
 --   use different difficulty adjustment algorithms etc.
 class ( CryptoHashable (Nonce cfg)
       , Serialise (Nonce cfg)
+      , Show (Nonce cfg)
       , Typeable cfg
       ) => KVConfig cfg where
   -- | Type of nonce. It depends on configuration.

--- a/hschain-PoW/HSChain/PoW/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/Consensus.hs
@@ -50,6 +50,7 @@ module HSChain.PoW.Consensus
   , BlockError(..)
     -- * Light consensus
   , LightConsensus(..)
+  , createLightConsensus
   , lightBlockIndex
   , bestLightHead
   , processLightHeader
@@ -61,12 +62,12 @@ import Control.Lens     hiding (pattern Empty, (|>), index)
 import Control.Monad
 import Control.Monad.Except
 import Control.Monad.State.Strict
-import Data.List          (sortOn)
+import Data.List          (sortOn,maximumBy)
 import Data.Typeable      (Typeable)
 import Data.Maybe
 import Data.Sequence      (Seq(Empty,(:<|),(:|>)),(|>))
 import Data.Set           (Set)
-import Data.Ord           (Down(..))
+import Data.Ord           (Down(..), comparing)
 import qualified Data.Aeson      as JSON
 import qualified Data.Set        as Set
 import qualified Data.Sequence   as Seq
@@ -523,6 +524,14 @@ data LightConsensus b = LightConsensus
   }
 
 makeLenses ''LightConsensus
+
+createLightConsensus :: (BlockData b) => BlockIndex b -> LightConsensus b
+createLightConsensus bIdx = LightConsensus
+  { _lightBlockIndex = bIdx
+  , _bestLightHead   = (bh, makeLocator bh)
+  }
+  where
+    bh = maximumBy (comparing bhWork) $ blockIndexHeads bIdx
 
 processLightHeader
   :: (BlockData b, MonadIO m)

--- a/hschain-PoW/HSChain/PoW/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/Consensus.hs
@@ -525,13 +525,16 @@ data LightConsensus b = LightConsensus
 
 makeLenses ''LightConsensus
 
-createLightConsensus :: (BlockData b) => BlockIndex b -> LightConsensus b
-createLightConsensus bIdx = LightConsensus
+createLightConsensus :: (BlockData b) => Block b -> BlockIndex b -> LightConsensus b
+createLightConsensus genesis bIdx = LightConsensus
   { _lightBlockIndex = bIdx
   , _bestLightHead   = (bh, makeLocator bh)
   }
   where
-    bh = maximumBy (comparing bhWork) $ blockIndexHeads bIdx
+    Just bhGen = blockID genesis `lookupIdx` bIdx
+    bh = case blockIndexHeads bIdx of
+      []  -> bhGen
+      bhs -> maximumBy (comparing bhWork) bhs
 
 processLightHeader
   :: (BlockData b, MonadIO m)

--- a/hschain-PoW/HSChain/PoW/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/Consensus.hs
@@ -20,6 +20,7 @@ module HSChain.PoW.Consensus
   , makeLocator
     -- * View on blockchain state
   , StateView(..)
+  , stateBID
   , StateView'
   , BlockOf
   , HeaderOf
@@ -118,8 +119,8 @@ class BlockData (BlockType view) => StateView view where
   type BlockType view :: (* -> *) -> *
   type MonadOf   view :: * -> *
 
-  -- | Hash of block for which state is calculated
-  stateBID :: view -> BlockID (BlockType view)
+  -- | Point in block registry for which state is calculated
+  stateBH :: view -> BHOf view
   -- | Apply block on top of current state. Function should return
   --   @Nothing@ if block is not valid. It's always called with @BH@
   --   corresponding to given block. If it's not the case it's
@@ -139,6 +140,9 @@ class BlockData (BlockType view) => StateView view where
   --   transaction in the mempool.
   checkTx :: view -> TxOf view -> MonadOf view (Either (BlockExceptionOf view) ())
 
+-- | Hash of block for which state is calculated
+stateBID :: StateView view => view -> BlockID (BlockType view)
+stateBID = bhBID . stateBH
 
 class ( StateView view
       , m ~ MonadOf view

--- a/hschain-PoW/HSChain/PoW/Node.hs
+++ b/hschain-PoW/HSChain/PoW/Node.hs
@@ -7,8 +7,7 @@
 --
 -- Copyright (C) ... 2020
 module HSChain.PoW.Node
-  ( Cfg(..)
-  , genericMiningLoop
+  ( genericMiningLoop
     -- * Block storage
   , inMemoryDB
   , blockDatabase
@@ -18,32 +17,14 @@ import Control.Concurrent
 import Control.Monad
 import Control.Monad.Cont
 
-import Data.Word
-import qualified Data.Aeson as JSON
-import GHC.Generics (Generic)
-
 import HSChain.Control.Channels
 import HSChain.PoW.Consensus
-import HSChain.Logger
 import HSChain.PoW.P2P
 import HSChain.PoW.Types
 import HSChain.PoW.Store
-import HSChain.Network.Types
 import HSChain.Control.Util
 import HSChain.Control.Class
-import HSChain.Config
 
--- |Node's configuration.
-data Cfg = Cfg
-  { cfgPort   :: Word16
-  , cfgPeers  :: [NetAddr]
-  , cfgLog    :: [ScribeSpec]
-  , cfgMaxH   :: Maybe Height
-  , cfgDB     :: Maybe FilePath
-  , cfgWebAPI :: Maybe Int
-  }
-  deriving stock (Show, Generic)
-  deriving (JSON.FromJSON) via SnakeCase (DropSmart (Config Cfg))
 
 
 genericMiningLoop

--- a/hschain-PoW/HSChain/PoW/P2P.hs
+++ b/hschain-PoW/HSChain/PoW/P2P.hs
@@ -85,7 +85,18 @@ startNodeTest cfg netAPI seeds db consensus = do
   -- Start mempool
   (mempoolAPI,MempoolCh{..}) <- startMempool db (consensus ^. bestHead . _2)
   -- Start PEX
-  runPEX cfg netAPI mempoolAPI mempoolAnnounces seeds blockReg sinkBOX mkSrcAnn (readTVar bIdx) db
+  let pexCh = PexCh
+        { pexNetCfg         = cfg
+        , pexNetAPI         = netAPI
+        , pexSeedNodes      = seeds
+        , pexMempoolAPI     = mempoolAPI
+        , pexMkMempoolAnn   = mempoolAnnounces
+        , pexMkConsensusAnn = mkSrcAnn
+        , pexSinkBox        = sinkBOX
+        , pexConsesusState  = readTVar bIdx
+        }
+
+  runPEX pexCh blockReg db
   -- Consensus thread
   let consensusCh = ConsensusCh
         { bcastAnnounce    = sinkAnn

--- a/hschain-PoW/HSChain/PoW/P2P.hs
+++ b/hschain-PoW/HSChain/PoW/P2P.hs
@@ -52,12 +52,11 @@ startNode
      )
   => NetCfg
   -> NetworkAPI
-  -> [NetAddr]
   -> BlockDB   m b
   -> Consensus view
   -> ContT r m (PoW view)
-startNode cfg netAPI seeds db consensus
-  = fst <$> startNodeTest cfg netAPI seeds db consensus
+startNode cfg netAPI db consensus
+  = fst <$> startNodeTest cfg netAPI db consensus
 
 -- | Same as startNode but expose internal interfacees for testing
 startNodeTest
@@ -69,13 +68,12 @@ startNodeTest
      )
   => NetCfg
   -> NetworkAPI
-  -> [NetAddr]
   -> BlockDB   m b
   -> Consensus view
   -> ContT r m ( PoW view
                , Sink (BoxRX m b)
                )
-startNodeTest cfg netAPI seeds db consensus = do
+startNodeTest cfg netAPI db consensus = do
   lift $ logger InfoS "Starting PoW node" ()
   (sinkBOX,    srcBOX)     <- queuePair
   (sinkAnn,    mkSrcAnn)   <- broadcastPair
@@ -89,7 +87,6 @@ startNodeTest cfg netAPI seeds db consensus = do
   let pexCh = PexCh
         { pexNetCfg         = cfg
         , pexNetAPI         = netAPI
-        , pexSeedNodes      = seeds
         , pexMempoolAPI     = mempoolAPI
         , pexMkAnnounce     = liftA2 (<>)
             (fmap GossipAnn <$> mkSrcAnn)

--- a/hschain-PoW/HSChain/PoW/P2P.hs
+++ b/hschain-PoW/HSChain/PoW/P2P.hs
@@ -87,7 +87,7 @@ startNodeTest cfg netAPI db consensus = do
   let pexCh = PexCh
         { pexNodeCfg        = cfg
         , pexNetAPI         = netAPI
-        , pexMempoolAPI     = mempoolAPI
+        , pexSinkTX         = postTransaction mempoolAPI
         , pexMkAnnounce     = liftA2 (<>)
             (fmap GossipAnn <$> mkSrcAnn)
             (fmap GossipTX  <$> mempoolAnnounces)

--- a/hschain-PoW/HSChain/PoW/P2P.hs
+++ b/hschain-PoW/HSChain/PoW/P2P.hs
@@ -100,13 +100,13 @@ startNodeTest cfg netAPI db consensus = do
             (fmap GossipAnn <$> mkSrcAnn)
             (fmap GossipTX  <$> mempoolAnnounces)
         , pexSinkBox        = sinkBOX
+        , pexBlockRegistry  = blockReg
         , pexConsesusState  = do c <- readTVar bConsesus
                                  pure ( c ^. blockIndex
                                       , c ^. bestHead . _1 . to stateBH
                                       , c ^. bestHead . _2)
         }
-
-  runPEX pexCh blockReg db
+  runPEX pexCh db
   -- Consensus thread
   let consensusCh = ConsensusCh
         { bcastAnnounce    = sinkAnn

--- a/hschain-PoW/HSChain/PoW/P2P.hs
+++ b/hschain-PoW/HSChain/PoW/P2P.hs
@@ -50,7 +50,7 @@ startNode
      , Serialise (Tx b)
      , StateView' view m b
      )
-  => NetCfg
+  => NodeCfg
   -> NetworkAPI
   -> BlockDB   m b
   -> Consensus view
@@ -66,7 +66,7 @@ startNodeTest
      , Serialise (Tx b)
      , StateView' view m b
      )
-  => NetCfg
+  => NodeCfg
   -> NetworkAPI
   -> BlockDB   m b
   -> Consensus view
@@ -85,7 +85,7 @@ startNodeTest cfg netAPI db consensus = do
   (mempoolAPI,MempoolCh{..}) <- startMempool db (consensus ^. bestHead . _2)
   -- Start PEX
   let pexCh = PexCh
-        { pexNetCfg         = cfg
+        { pexNodeCfg        = cfg
         , pexNetAPI         = netAPI
         , pexMempoolAPI     = mempoolAPI
         , pexMkAnnounce     = liftA2 (<>)

--- a/hschain-PoW/HSChain/PoW/P2P.hs
+++ b/hschain-PoW/HSChain/PoW/P2P.hs
@@ -8,6 +8,7 @@ module HSChain.PoW.P2P
   ) where
 
 import Codec.Serialise
+import Control.Applicative
 import Control.Lens
 import Control.Concurrent.MVar
 import Control.Concurrent.STM
@@ -90,8 +91,9 @@ startNodeTest cfg netAPI seeds db consensus = do
         , pexNetAPI         = netAPI
         , pexSeedNodes      = seeds
         , pexMempoolAPI     = mempoolAPI
-        , pexMkMempoolAnn   = mempoolAnnounces
-        , pexMkConsensusAnn = mkSrcAnn
+        , pexMkAnnounce     = liftA2 (<>)
+            (fmap GossipAnn <$> mkSrcAnn)
+            (fmap GossipTX  <$> mempoolAnnounces)
         , pexSinkBox        = sinkBOX
         , pexConsesusState  = readTVar bIdx
         }

--- a/hschain-PoW/HSChain/PoW/P2P.hs
+++ b/hschain-PoW/HSChain/PoW/P2P.hs
@@ -1,10 +1,14 @@
 {-# LANGUAGE KindSignatures #-}
 -- |
 module HSChain.PoW.P2P
-  ( PoW(..)
+  ( -- * Full node
+    PoW(..)
   , MempoolAPI(..)
   , startNode
   , startNodeTest
+    -- * Light node
+  , LightPoW(..)
+  , lightNode
   ) where
 
 import Codec.Serialise
@@ -28,6 +32,10 @@ import HSChain.PoW.P2P.Types
 import HSChain.PoW.Types
 import HSChain.Types.Merkle.Types
 
+
+----------------------------------------------------------------
+-- Full node
+----------------------------------------------------------------
 
 -- | Dictionary with functions for interacting with consensus engine
 data PoW view = PoW
@@ -123,3 +131,25 @@ startNodeTest cfg netAPI db consensus = do
           }
     , sinkBOX
     )
+
+
+----------------------------------------------------------------
+-- Light node
+----------------------------------------------------------------
+
+data LightPoW b = LightPoW
+  { bestHeadUpdates :: STM (Src (BH b))
+  }
+
+lightNode
+  :: ( MonadMask m, MonadFork m, MonadLogger m
+     , Serialise (b Identity)
+     , Serialise (b Proxy)
+     , Serialise (Tx b)
+     )
+  => NodeCfg
+  -> NetworkAPI
+  -> BlockDB   m b
+  -> ContT r m (LightPoW b)
+lightNode _cfg _netAPI _db = undefined
+

--- a/hschain-PoW/HSChain/PoW/P2P.hs
+++ b/hschain-PoW/HSChain/PoW/P2P.hs
@@ -183,6 +183,6 @@ lightNode cfg netAPI db consensus = do
         , lcAnnounce = sinkAnn
         , lcRX       = srcBOX
         }
-  cforkLinked $ threadLightConsensus db undefined lightCh
+  cforkLinked $ threadLightConsensus db consensus lightCh
   -- Done
   pure LightPoW { bestHeadUpdates = mkSrcUpd }

--- a/hschain-PoW/HSChain/PoW/P2P/Handler/Consensus.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Handler/Consensus.hs
@@ -3,6 +3,9 @@
 module HSChain.PoW.P2P.Handler.Consensus
   ( ConsensusCh(..)
   , threadConsensus
+    -- * Light consensus
+  , LightConsensusCh(..)
+  , threadLightConsensus
   ) where
 
 import Control.Lens
@@ -20,6 +23,10 @@ import HSChain.PoW.P2P.Types
 import HSChain.PoW.Types
 import HSChain.Logger
 
+
+----------------------------------------------------------------
+-- Full consensus
+----------------------------------------------------------------
 
 -- | Channels for sending data to and from consensus thread
 data ConsensusCh view = ConsensusCh
@@ -123,6 +130,100 @@ consensusMonitor db (BoxRX message)
       Left ErrB'UnknownBlock     -> error "Impossible: we should'n get unknown block"
       Left (ErrB'InvalidBlock e) -> do logger ErrorS "Bad mined block (context-free)" (sl "err" e)
                                        return $ Left $ Peer'Punish $ toException e
+    -- Handle errors during header processing. Not that KnownHeader is
+    -- not really an error
+    handleHeaderError = mapExceptT $ \action -> action >>= \case
+      Right () -> return $ Right ()
+      Left  e  -> case e of
+        ErrH'KnownHeader         -> return $ Right ()
+        ErrH'HeightMismatch      -> punish
+        ErrH'UnknownParent       -> punish
+        ErrH'ValidationFailure{} -> punish
+        ErrH'BadParent           -> punish
+        where
+          punish = do logger WarningS "Bad header" (sl "err" e)
+                      return $ Left $ Peer'Punish $ toException e
+    -- Convert error from ExceptT
+    evalError action = runExceptT action >>= \case
+      Right () -> return Peer'Noop
+      Left  e  -> return e
+
+
+----------------------------------------------------------------
+-- Light consensus
+----------------------------------------------------------------
+
+-- | Channels for sending data to and from consensus thread
+data LightConsensusCh m b = LightConsensusCh
+  { lcAnnounce :: Sink (MsgAnn b)
+    -- ^ Broadcast channel for gossip announcements (we got new best head)
+  , lcUpdate   :: Sink (LightConsensus b)
+    -- ^ Broadcast channel for announcing new head for mining etc.
+  , lcRX       :: Src  (BoxRX m b)
+    -- ^ Messages from gossip
+  }
+
+
+-- | Thread that reacts to messages from peers and updates consensus
+--   accordingly
+threadLightConsensus
+  :: (MonadIO m, MonadLogger m, MonadCatch m, BlockData b)
+  => BlockDB m b
+  -> LightConsensus b
+  -> LightConsensusCh m b
+  -> m x
+threadLightConsensus db consensus0 LightConsensusCh{..} = descendNamespace "cns" $ logOnException $ do
+  logger InfoS "Staring consensus" ()
+  flip evalStateT consensus0
+    $ forever
+    $ do bh <- use $ bestLightHead . _1
+         lightConsensusMonitor db =<< awaitIO lcRX
+         bh' <- use $ bestLightHead . _1
+         when (bhBID bh /= bhBID bh') $ do
+           logger InfoS "New head" ( sl "h"   (bhHeight bh')
+                                  <> sl "bid" (bhBID    bh')
+                                   )
+           sinkIO lcAnnounce $ AnnBestHead $ asHeader bh'
+           sinkIO lcUpdate =<< get
+
+
+-- Handler for messages coming from peer.
+lightConsensusMonitor
+  :: (MonadLogger m, MonadIO m, BlockData b)
+  => BlockDB m b
+  -> BoxRX m b
+  -> StateT (LightConsensus b) m ()
+lightConsensusMonitor db (BoxRX message)
+  = message $ logR <=< \case
+      RxAnn     m  -> handleAnnounce m
+      RxHeaders hs -> do
+        lift $ logger DebugS "Got RxHeaders" (sl "bid" (blockID <$> hs))
+        evalError $ mapM_ (handleHeaderError . processLightHeader db) hs
+      -- Block messages are simply ignored
+      RxBlock _ -> pure Peer'Noop
+      RxMined _ -> pure Peer'Noop
+  where
+    -- Log out responce to peer
+    logR m = do lift $ logger DebugS "Resp" (sl "v" (show m))
+                return m
+    -- Handler for announces coming from peers (they come unrequested)
+    handleAnnounce (AnnBestHead h) = do
+      lift $ logger DebugS "Got AnnBestHead" (  sl "bid" (blockID h)
+                                             <> sl "H"   (blockHeight h)
+                                             )
+      runExceptT (processLightHeader db h) >>= \case
+        Right () -> return Peer'Noop
+        Left  e  -> case e of
+          ErrH'KnownHeader         -> return Peer'Noop
+          ErrH'HeightMismatch      -> punish
+          ErrH'ValidationFailure{} -> punish
+          ErrH'BadParent           -> punish
+          -- We got announce that we couldn't attach to block tree. So
+          -- we need that peer to catch up
+          ErrH'UnknownParent     -> return Peer'EnterCatchup
+          where
+            punish = do logger WarningS "Bad AnnBestHead" (sl "err" e)
+                        return $ Peer'Punish $ toException e   
     -- Handle errors during header processing. Not that KnownHeader is
     -- not really an error
     handleHeaderError = mapExceptT $ \action -> action >>= \case

--- a/hschain-PoW/HSChain/PoW/P2P/Handler/PEX.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Handler/PEX.hs
@@ -39,7 +39,6 @@ import HSChain.Types.Merkle.Types
 data PexCh view = PexCh
   { pexNetCfg         :: NetCfg
   , pexNetAPI         :: NetworkAPI
-  , pexSeedNodes      :: [NetAddr]
   , pexMempoolAPI     :: MempoolAPI view
   , pexSinkBox        :: Sink (BoxRX (MonadOf view) (BlockType view))
   , pexMkAnnounce     :: STM (Src (GossipMsg (BlockType view)))
@@ -58,7 +57,7 @@ runPEX
   -> BlockDB m b
   -> ContT r m ()
 runPEX PexCh{..} blockReg db = do
-  reg                <- newPeerRegistry pexSeedNodes
+  reg                <- newPeerRegistry $ initialPeers pexNetCfg
   nonces             <- newNonceSet
   (sinkAddr,srcAddr) <- queuePair
   (sinkAsk,mkSrcAsk) <- broadcastPair

--- a/hschain-PoW/HSChain/PoW/P2P/Handler/PEX.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Handler/PEX.hs
@@ -40,6 +40,7 @@ data PexCh m b = PexCh
   , pexNetAPI         :: NetworkAPI
   , pexSinkTX         :: Sink (Tx b)
   , pexSinkBox        :: Sink (BoxRX m b)
+  , pexBlockRegistry  :: BlockRegistry b
   , pexMkAnnounce     :: STM (Src (GossipMsg b))
   , pexConsesusState  :: STM (BlockIndex b, BH b, Locator b)
   }
@@ -52,10 +53,9 @@ runPEX
      , BlockData b
      )
   => PexCh m b
-  -> BlockRegistry b
   -> BlockDB m b
   -> ContT r m ()
-runPEX PexCh{..} blockReg db = do
+runPEX PexCh{..} db = do
   reg                <- newPeerRegistry $ initialPeers pexNodeCfg
   nonces             <- newNonceSet
   (sinkAddr,srcAddr) <- queuePair
@@ -69,7 +69,7 @@ runPEX PexCh{..} blockReg db = do
           , peerSinkConsensus  = pexSinkBox
           , peerSinkTX         = pexSinkTX
           , peerCatchup        = catchup
-          , peerReqBlocks      = blockReg
+          , peerReqBlocks      = pexBlockRegistry
           , peerConnections    = connectedPeersList reg
           , peerConsensusState = pexConsesusState
           , peerBlockDB        = db

--- a/hschain-PoW/HSChain/PoW/P2P/Handler/PEX.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Handler/PEX.hs
@@ -41,9 +41,8 @@ data PexCh view = PexCh
   , pexNetAPI         :: NetworkAPI
   , pexSeedNodes      :: [NetAddr]
   , pexMempoolAPI     :: MempoolAPI view
-  , pexMkMempoolAnn   :: STM (Src (MsgTX  (BlockType view)))
-  , pexMkConsensusAnn :: STM (Src (MsgAnn (BlockType view)))
   , pexSinkBox        :: Sink (BoxRX (MonadOf view) (BlockType view))
+  , pexMkAnnounce     :: STM (Src (GossipMsg (BlockType view)))
   , pexConsesusState  :: STM (Consensus view)
   }
 
@@ -65,9 +64,8 @@ runPEX PexCh{..} blockReg db = do
   (sinkAsk,mkSrcAsk) <- broadcastPair
   catchup            <- newCatchupThrottle
   let mkChans = do
-        peerBCastAnn     <- pexMkConsensusAnn
         peerBCastAskPeer <- mkSrcAsk
-        peerBCastAnnTx   <- pexMkMempoolAnn
+        peerBCastAnn     <- pexMkAnnounce
         return PeerChans
           { peerSinkNewAddr   = sinkAddr
           , peerSinkConsensus = pexSinkBox

--- a/hschain-PoW/HSChain/PoW/P2P/Handler/Peer.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Handler/Peer.hs
@@ -56,7 +56,7 @@ runPeer conn mempoolAPI chans@PeerChans{..} = logOnException $ do
   do s <- atomicallyIO peerConsensuSt
      sinkIO sinkGossip $ GossipAnn $ AnnBestHead $ s ^. bestHead . _1 . to asHeader
   runConcurrently
-    [ peerSend    conn (srcGossip <> fmap GossipAnn peerBCastAnn <> fmap GossipTX peerBCastAnnTx)
+    [ peerSend    conn (srcGossip <> peerBCastAnn)
     , peerRecv    conn     st chans sinkGossip mempoolAPI
     , peerRequestHeaders   st chans sinkGossip
     , peerRequestBlock     st chans sinkGossip

--- a/hschain-PoW/HSChain/PoW/P2P/Handler/Peer.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Handler/Peer.hs
@@ -80,7 +80,7 @@ data PeerState b = PeerState
   }
 
 
--- Thread that issues
+-- Thread that requests header in case we're behind and need to catch up.
 peerRequestHeaders
   :: (MonadIO m, MonadLogger m, MonadCatch m, StateView' view m b)
   => PeerState b
@@ -107,7 +107,7 @@ peerRequestHeaders PeerState{..} PeerChans{..} sinkGossip =
   where
     exitCatchup = writeTVar inCatchup False
 
-
+-- Thread that requests missing blocks
 peerRequestBlock
   :: (MonadIO m, MonadLogger m, MonadCatch m, BlockData b, BlockType view ~ b)
   => PeerState b

--- a/hschain-PoW/HSChain/PoW/P2P/Types.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Types.hs
@@ -205,9 +205,11 @@ data PeerChans view = PeerChans
   , peerBCastAskPeer  :: Src   AskPeers
     -- ^ Broadcast channel for asking for more peers
   , peerCatchup       :: CatchupThrottle
+    -- ^ Lock for catching up when downloading headers
   , peerReqBlocks     :: BlockRegistry (BlockType view)
+    -- ^ Set of block in process of being requested
   , peerConnections   :: STM [NetAddr]
-    -- ^
+    -- ^ Set of known peers
   , peerConsensuSt    :: STM (Consensus view)
     -- ^ Current consensus state
   , peerBlockDB       :: BlockDB (MonadOf view) (BlockType view)

--- a/hschain-PoW/HSChain/PoW/P2P/Types.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Types.hs
@@ -28,7 +28,7 @@ module HSChain.PoW.P2P.Types
 
   , CatchupThrottle(..)
   , ReleaseCatchupThrottle(..)
-  , NetCfg(..)
+  , NodeCfg(..)
   ) where
 
 import Control.Concurrent.STM
@@ -50,7 +50,7 @@ import HSChain.PoW.P2P.Handler.BlockRequests
 -- Configuration
 ----------------------------------------------------------------
 
-data NetCfg = NetCfg
+data NodeCfg = NodeCfg
   { nKnownPeers     :: !Int
     -- ^ Number of peers we want to know about
   , nConnectedPeers :: !Int

--- a/hschain-PoW/HSChain/PoW/P2P/Types.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Types.hs
@@ -198,7 +198,7 @@ data AskPeers = AskPeers
 data PeerChans m b = PeerChans
   { peerSinkNewAddr    :: Sink [NetAddr]
     -- ^ Send newly received addresses
-  , peerSinkTX        :: Sink (Tx b)
+  , peerSinkTX         :: Sink (Tx b)
     -- ^ Sink for posting transactions
   , peerSinkConsensus  :: Sink (BoxRX m b)
     -- ^ Send new command to consensus

--- a/hschain-PoW/HSChain/PoW/P2P/Types.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Types.hs
@@ -198,6 +198,8 @@ data AskPeers = AskPeers
 data PeerChans view = PeerChans
   { peerSinkNewAddr   :: Sink [NetAddr]
     -- ^ Send newly received addresses
+  , peerSinkTX        :: Sink (TxOf view)
+    -- ^ Sink for posting transactions
   , peerSinkConsensus :: Sink (BoxRX (MonadOf view) (BlockType view))
     -- ^ Send new command to consensus
   , peerBCastAnn      :: Src  (GossipMsg (BlockType view))
@@ -213,6 +215,7 @@ data PeerChans view = PeerChans
   , peerConsensuSt    :: STM (Consensus view)
     -- ^ Current consensus state
   , peerBlockDB       :: BlockDB (MonadOf view) (BlockType view)
+    -- ^ Block database
   }
 
 data SentRequest b

--- a/hschain-PoW/HSChain/PoW/P2P/Types.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Types.hs
@@ -46,12 +46,22 @@ import HSChain.Types.Merkle.Types
 import HSChain.Control.Channels
 import HSChain.PoW.P2P.Handler.BlockRequests
 
-
+----------------------------------------------------------------
+-- Configuration
+----------------------------------------------------------------
 
 data NetCfg = NetCfg
   { nKnownPeers     :: !Int
+    -- ^ Number of peers we want to know about
   , nConnectedPeers :: !Int
+    -- ^ Number of peers we want to connect to
+  , initialPeers    :: [NetAddr]
+    -- ^ Set of initial addresses to connect to
   }
+  deriving (Show,Eq,Generic)
+
+
+
 
 ----------------------------------------------------------------
 -- Handshake

--- a/hschain-PoW/HSChain/PoW/P2P/Types.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Types.hs
@@ -190,12 +190,10 @@ data PeerChans view = PeerChans
     -- ^ Send newly received addresses
   , peerSinkConsensus :: Sink (BoxRX (MonadOf view) (BlockType view))
     -- ^ Send new command to consensus
-  , peerBCastAnn      :: Src  (MsgAnn (BlockType view))
+  , peerBCastAnn      :: Src  (GossipMsg (BlockType view))
     -- ^ Broadcast channel for announces
   , peerBCastAskPeer  :: Src   AskPeers
     -- ^ Broadcast channel for asking for more peers
-  , peerBCastAnnTx    :: Src  (MsgTX (BlockType view))
-    -- ^ Broadcast channel for new tx announces
   , peerCatchup       :: CatchupThrottle
   , peerReqBlocks     :: BlockRegistry (BlockType view)
   , peerConnections   :: STM [NetAddr]

--- a/hschain-PoW/HSChain/PoW/P2P/Types.hs
+++ b/hschain-PoW/HSChain/PoW/P2P/Types.hs
@@ -195,26 +195,26 @@ data CmdPeer b
 data AskPeers = AskPeers
 
 -- | Channels for peer for communication with rest of the world
-data PeerChans view = PeerChans
-  { peerSinkNewAddr   :: Sink [NetAddr]
+data PeerChans m b = PeerChans
+  { peerSinkNewAddr    :: Sink [NetAddr]
     -- ^ Send newly received addresses
-  , peerSinkTX        :: Sink (TxOf view)
+  , peerSinkTX        :: Sink (Tx b)
     -- ^ Sink for posting transactions
-  , peerSinkConsensus :: Sink (BoxRX (MonadOf view) (BlockType view))
+  , peerSinkConsensus  :: Sink (BoxRX m b)
     -- ^ Send new command to consensus
-  , peerBCastAnn      :: Src  (GossipMsg (BlockType view))
+  , peerBCastAnn       :: Src  (GossipMsg b)
     -- ^ Broadcast channel for announces
-  , peerBCastAskPeer  :: Src   AskPeers
+  , peerBCastAskPeer   :: Src   AskPeers
     -- ^ Broadcast channel for asking for more peers
-  , peerCatchup       :: CatchupThrottle
+  , peerCatchup        :: CatchupThrottle
     -- ^ Lock for catching up when downloading headers
-  , peerReqBlocks     :: BlockRegistry (BlockType view)
+  , peerReqBlocks      :: BlockRegistry b
     -- ^ Set of block in process of being requested
-  , peerConnections   :: STM [NetAddr]
+  , peerConnections    :: STM [NetAddr]
     -- ^ Set of known peers
-  , peerConsensuSt    :: STM (Consensus view)
+  , peerConsensusState :: STM (BlockIndex b, BH b, Locator b)
     -- ^ Current consensus state
-  , peerBlockDB       :: BlockDB (MonadOf view) (BlockType view)
+  , peerBlockDB        :: BlockDB m b
     -- ^ Block database
   }
 

--- a/hschain-PoW/HSChain/PoW/Tests.hs
+++ b/hschain-PoW/HSChain/PoW/Tests.hs
@@ -86,7 +86,17 @@ testIdempotence chain db = do
     fetch ("Idempotence: "++show (blockHeight b)) b
   -- Fetchall
   liftIO . assertEqual "All headers" (take 4 $ map toHeader $ chain) =<< retrieveAllHeaders db
+  -- Block after header
+  do let b = chain !! 8
+     storeHeader db (toHeader b) >> fetchH "Fetch header"       b
+     storeBlock  db b            >> fetch  "Block after header" b
+  -- Header after block
+  do let b = chain !! 8
+     storeBlock  db b            >> fetch "Header after block 1" b
+     storeHeader db (toHeader b) >> fetch "Header after block 2" b
   where
+    fetchH nm b = do
+      assertEqual ("Yes: " ++ nm) (Just (toHeader b)) =<< retrieveHeader db (blockID b)
     fetch nm b = do
       assertEqual ("Yes: " ++ nm) (Just b)            =<< retrieveBlock  db (blockID b)
       assertEqual ("Yes: " ++ nm) (Just (toHeader b)) =<< retrieveHeader db (blockID b)

--- a/hschain-PoW/HSChain/PoW/Types.hs
+++ b/hschain-PoW/HSChain/PoW/Types.hs
@@ -106,7 +106,7 @@ newtype DTime = DTime Int64
 
 -- | Compute difference between two timestamps
 (.-.) :: Time -> Time -> DTime
-Time t1 .-. Time t2 = DTime (t2 - t1)
+Time t1 .-. Time t2 = DTime (t1 - t2)
 
 -- | Add difference to a time stamp
 (.+) :: Time -> DTime -> Time

--- a/hschain-PoW/HSChain/PoW/Types.hs
+++ b/hschain-PoW/HSChain/PoW/Types.hs
@@ -206,6 +206,7 @@ instance ( IsMerkle f
 class ( Show (BlockID b), Ord (BlockID b), Serialise (BlockID b)
       , Show (TxID    b), Ord (TxID    b), Serialise (TxID    b)
       , Show (Tx b)
+      , Show (b Proxy), Show (b Identity)
       , JSON.ToJSON (BlockID b), JSON.FromJSON (BlockID b)
       , JSON.ToJSON (TxID    b), JSON.FromJSON (TxID    b)
       , MerkleMap b, Typeable b

--- a/hschain-PoW/exe/coin-light.hs
+++ b/hschain-PoW/exe/coin-light.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE ApplicativeDo              #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE NumDecimals                #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+-- |
+module Main where
+
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Monad.IO.Class
+import Control.Monad.Reader
+import Control.Monad.Trans.Cont
+import Control.Lens
+import Data.Maybe
+import Data.Word
+import qualified Data.Aeson      as JSON
+import qualified Data.Map.Strict as Map
+import qualified Data.Vector     as V
+import Data.Yaml.Config (loadYamlSettings, requireEnv)
+import Options.Applicative
+import GHC.Generics (Generic)
+
+import HSChain.Control.Channels
+import HSChain.Control.Util
+import HSChain.Crypto
+import HSChain.Examples.Coin
+import HSChain.Logger
+import HSChain.Network.TCP
+import HSChain.Network.Types
+import HSChain.PoW.Consensus
+import HSChain.PoW.P2P
+import HSChain.PoW.P2P.Types
+import HSChain.PoW.Types
+import HSChain.Store.Query
+import HSChain.Types.Merkle.Types
+import HSChain.Config
+
+----------------------------------------------------------------
+--
+----------------------------------------------------------------
+
+-- |Node's configuration.
+data Cfg = Cfg
+  { cfgPort    :: Word16
+  , cfgPeers   :: [NetAddr]
+  , cfgLog     :: [ScribeSpec]
+  , cfgDB      :: Maybe FilePath
+  }
+  deriving stock (Show, Generic)
+  deriving (JSON.FromJSON) via SnakeCase (DropSmart (Config Cfg))
+
+genesis :: Block Coin
+genesis = Block
+  { blockHeight = Height 0
+  , blockTime   = Time 0
+  , prevBlock   = Nothing
+  , blockData   = Coin { coinData   = merkled []
+                       , coinNonce  = 0
+                       , coinTarget = Target $ 2^(256-16 :: Int)
+                       }
+  }
+
+main :: IO ()
+main = do
+  -- Parse configuration
+  Opts{..} <- customExecParser (prefs showHelpOnError)
+            $ info (helper <*> parser)
+              (  fullDesc
+              <> header   "PoW node settings"
+              <> progDesc ""
+              )
+  Cfg{..} <- loadYamlSettings optConfigPath [] requireEnv
+  -- Acquire resources
+  let net    = newNetworkTcp cfgPort
+      netcfg = NodeCfg { nKnownPeers     = 3
+                       , nConnectedPeers = 3
+                       , initialPeers    = cfgPeers
+                       }
+  withConnection (fromMaybe "" cfgDB) $ \conn -> 
+    withLogEnv "" "" (map makeScribe cfgLog) $ \logEnv -> runCoinT logEnv conn $ evalContT $ do
+      lift $ initCoinDB
+      lift $ storeCoinBlock genesis
+      bIdx <- lift $ buildBlockIndex coinDB
+      liftIO $ print $ Map.keys $ _blockIDMap bIdx
+      liftIO $ print $ map bhBID $ blockIndexHeads bIdx
+      let c0 = createLightConsensus bIdx
+      pow <- lightNode netcfg net coinDB c0
+      -- report progress
+      void $ liftIO $ forkIO $ do
+        ch <- atomicallyIO (bestHeadUpdates pow)
+        forever $ do bh <- view (bestLightHead . _1) <$> awaitIO ch
+                     print (bhHeight bh, bhBID bh)
+                     print $ retarget bh
+      -- Wait forever
+      liftIO $ forever $ threadDelay maxBound
+
+txGeneratorLoop
+  :: (MonadReadDB m, MonadIO m)
+  => PoW (CoinState m) -> [PrivKey Alg] -> m ()
+txGeneratorLoop pow keyList = do
+  forever $ do
+    mtx <- generateTX keyVec keyMap
+    forM_ mtx $ sinkIO (postTransaction (mempoolAPI pow))
+    liftIO $ threadDelay 25e3
+  where
+    keyVec = V.fromList $ Map.keys keyMap
+    keyMap = Map.fromList [ (publicKey k, k) | k <- keyList ]
+
+
+----------------------------------------------------------------
+--
+----------------------------------------------------------------
+
+data Opts = Opts
+  { optConfigPath :: [FilePath]     -- ^ Paths to configuration
+  }
+
+parser :: Parser Opts
+parser = do
+  optConfigPath <- some $ strArgument
+    (  metavar "PATH"
+    <> help  "Path to configuration"
+    <> showDefault
+    )
+  return Opts{..}

--- a/hschain-PoW/exe/coin-light.hs
+++ b/hschain-PoW/exe/coin-light.hs
@@ -84,7 +84,7 @@ main = do
       bIdx <- lift $ buildBlockIndex coinDB
       liftIO $ print $ Map.keys $ _blockIDMap bIdx
       liftIO $ print $ map bhBID $ blockIndexHeads bIdx
-      let c0 = createLightConsensus bIdx
+      let c0 = createLightConsensus genesis bIdx
       pow <- lightNode netcfg net coinDB c0
       -- report progress
       void $ liftIO $ forkIO $ do

--- a/hschain-PoW/exe/coin-node.hs
+++ b/hschain-PoW/exe/coin-node.hs
@@ -87,14 +87,15 @@ main = do
   Cfg{..} <- loadYamlSettings optConfigPath [] requireEnv
   -- Acquire resources
   let net    = newNetworkTcp cfgPort
-      netcfg = NetCfg { nKnownPeers     = 3
-                      , nConnectedPeers = 3
-                      }
+      netcfg = NodeCfg { nKnownPeers     = 3
+                       , nConnectedPeers = 3
+                       , initialPeers    = cfgPeers
+                       }
   withConnection (fromMaybe "" cfgDB) $ \conn -> 
     withLogEnv "" "" (map makeScribe cfgLog) $ \logEnv -> runCoinT logEnv conn $ evalContT $ do
       (db, bIdx, sView) <- lift $ coinStateView genesis
       c0  <- lift $ createConsensus db sView bIdx
-      pow <- startNode netcfg net cfgPeers db c0
+      pow <- startNode netcfg net db c0
       -- report progress
       void $ liftIO $ forkIO $ do
         ch <- atomicallyIO (chainUpdate pow)

--- a/hschain-PoW/exe/coin-node.hs
+++ b/hschain-PoW/exe/coin-node.hs
@@ -99,7 +99,7 @@ main = do
       -- report progress
       void $ liftIO $ forkIO $ do
         ch <- atomicallyIO (chainUpdate pow)
-        forever $ do (bh,_) <- awaitIO ch
+        forever $ do bh <- stateBH <$> awaitIO ch
                      print (bhHeight bh, bhBID bh)
                      print $ retarget bh
       -- Start web node
@@ -116,7 +116,8 @@ main = do
       -- Mining loop
       forM_ cfgMinerPK $ \pk -> do
         cforkLinked $ genericMiningLoop
-          (\st bh t txs -> createCandidateBlock bh t <$> createCandidateBlockData pk st bh txs)
+          (\st t txs -> let bh = stateBH st
+                        in createCandidateBlock bh t <$> createCandidateBlockData pk st bh txs)
           pow
       -- Wait forever
       liftIO $ forever $ threadDelay maxBound

--- a/hschain-PoW/hschain-PoW.cabal
+++ b/hschain-PoW/hschain-PoW.cabal
@@ -119,6 +119,7 @@ Executable hschain-PoW-coin
                      , hschain-logger
                      , hschain-crypto
                      , hschain-control
+                     , hschain-config
                      --
                      , aeson
                      , katip
@@ -139,6 +140,31 @@ Executable hschain-PoW-coin
                      , warp
   hs-source-dirs:      exe
   Main-is:             coin-node.hs
+  default-extensions:
+    MonoLocalBinds
+    -- Deriving
+    DeriveAnyClass
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    DerivingVia
+    GeneralizedNewtypeDeriving
+    StandaloneDeriving
+    -- Sugar
+    BangPatterns
+    LambdaCase
+    MultiWayIf
+    RecordWildCards
+    OverloadedStrings
+    TypeOperators
+    -- Types
+    ScopedTypeVariables
+    TypeApplications
+    -- Instances
+    FlexibleContexts
+    FlexibleInstances
 
 Executable hschain-PoW-key
   Ghc-options:         -Wall -threaded -rtsopts "-with-rtsopts=-N -T -qn1 -A64M"

--- a/hschain-PoW/hschain-PoW.cabal
+++ b/hschain-PoW/hschain-PoW.cabal
@@ -166,6 +166,66 @@ Executable hschain-PoW-coin
     FlexibleContexts
     FlexibleInstances
 
+Executable hschain-PoW-light
+  Ghc-options:         -Wall -threaded -rtsopts "-with-rtsopts=-N -T -qn1 -A64M"
+  Default-Language:    Haskell2010
+  Build-Depends:       base                 >=4.9 && <5
+                     , hschain-PoW
+                     , hschain-net
+                     , hschain-merkle
+                     , hschain-types
+                     , hschain-db
+                     , hschain-logger
+                     , hschain-crypto
+                     , hschain-control
+                     , hschain-config
+                     --
+                     , aeson
+                     , katip
+                     , mtl
+                     , lens
+                     , text
+                     , bytestring
+                     , containers
+                     , vector
+                     , random
+                     , serialise
+                     , exceptions
+                     , transformers
+                     , optparse-applicative
+                     , yaml
+                     --
+                     , servant
+                     , servant-server
+                     , warp
+  hs-source-dirs:      exe
+  Main-is:             coin-light.hs
+  default-extensions:
+    MonoLocalBinds
+    -- Deriving
+    DeriveAnyClass
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    DerivingVia
+    GeneralizedNewtypeDeriving
+    StandaloneDeriving
+    -- Sugar
+    BangPatterns
+    LambdaCase
+    MultiWayIf
+    RecordWildCards
+    OverloadedStrings
+    TypeOperators
+    -- Types
+    ScopedTypeVariables
+    TypeApplications
+    -- Instances
+    FlexibleContexts
+    FlexibleInstances
+
 Executable hschain-PoW-key
   Ghc-options:         -Wall -threaded -rtsopts "-with-rtsopts=-N -T -qn1 -A64M"
   Default-Language:    Haskell2010

--- a/hschain-PoW/test/TM/Consensus.hs
+++ b/hschain-PoW/test/TM/Consensus.hs
@@ -231,7 +231,7 @@ testReorg2 = runTest
 
 
 
-bestHeadOK :: IsMerkle f => Consensus (KVState MockChain m) -> GBlock (KV MockChain) f -> [String]
+bestHeadOK :: (Monad m,IsMerkle f) => Consensus (KVState MockChain m) -> GBlock (KV MockChain) f -> [String]
 bestHeadOK c h
   | expected == got = []
   | otherwise       =
@@ -241,7 +241,7 @@ bestHeadOK c h
       ]
   where
     expected = blockID h
-    got      = c^.bestHead._1.to bhBID
+    got      = c ^. bestHead . _1 . to stateBH . to bhBID
 
 -- candidatesOK :: Consensus m (KV MockChain) -> [Header (KV MockChain)] -> [String]
 -- candidatesOK c hs
@@ -354,5 +354,5 @@ checkConsensus c = concat
   -- , [
   ]
   where
-    bestWork = bhWork $ c ^. bestHead . _1
+    bestWork = c ^. bestHead . _1 . to stateBH . to bhWork
 

--- a/hschain-PoW/test/TM/Consensus.hs
+++ b/hschain-PoW/test/TM/Consensus.hs
@@ -297,8 +297,10 @@ data Message
 
 runTest :: [Message] -> IO ()
 runTest msgList = runNoLogsT $ do
-  db <- inMemoryDB genesis
-  let s0 = consensusGenesis (head mockchain) $ kvMemoryView (blockID genesis)
+  db   <- inMemoryDB genesis
+  bIdx <- buildBlockIndex db
+  let Just bh = lookupIdx (blockID $ head mockchain) bIdx
+      s0      = consensusGenesis (head mockchain) $ kvMemoryView bh
   runExceptT (loop db s0 msgList) >>= \case
     Left  e  -> error $ unlines e
     Right () -> return ()

--- a/hschain-PoW/test/TM/Mempool.hs
+++ b/hschain-PoW/test/TM/Mempool.hs
@@ -92,9 +92,9 @@ checkMempoolContent MempoolAPI{..} expected = liftIO $ do
 
 checkRecv
   :: (MonadIO m, Eq (TxOf view), Show (TxOf view), StateView view)
-  => Src (BHOf view, view, [TxOf view]) -> [TxOf view] -> m ()
+  => Src (view, [TxOf view]) -> [TxOf view] -> m ()
 checkRecv ch expected = liftIO $ do
-  (_,_,txs) <- awaitIO ch
+  (_,txs) <- awaitIO ch
   expected @=? txs
 
 sendBlock :: (MerkleMap b, Monad m, MonadIO n) => Sink (BoxRX m b) -> GBlock b Identity -> n ()

--- a/hschain-PoW/test/TM/Mempool.hs
+++ b/hschain-PoW/test/TM/Mempool.hs
@@ -37,7 +37,7 @@ testMempoolRollback = runNoLogsT $ evalContT $ do
       sView = kvMemoryView (blockID genesis)
   db <- lift $ inMemoryDB genesis
   c0 <- lift $ createConsensus db sView =<< buildBlockIndex db
-  (pow,sinkBOX) <- startNodeTest netcfg net [] db c0
+  (pow,sinkBOX) <- startNodeTest netcfg net db c0
   let api@MempoolAPI{..} = mempoolAPI pow
   ch <- atomicallyIO mempoolUpdates
   -- First post transaction into mempool
@@ -72,9 +72,8 @@ testMempoolRollback = runNoLogsT $ evalContT $ do
     b2  = mineBlock [tx3] b1
     b3  = mineBlock [tx4] b2
     --
-    netcfg = NetCfg { nKnownPeers     = 3
-                    , nConnectedPeers = 3
-                    }
+    netcfg = NodeCfg 0 0 []
+
 
 
 checkMempoolContent

--- a/hschain-PoW/test/TM/P2P.hs
+++ b/hschain-PoW/test/TM/P2P.hs
@@ -131,7 +131,7 @@ runNetTest test = do
   let apiNode        = createMockNode net ipNode
       NetworkAPI{..} = createMockNode net ipOur
   runNoLogsT $ evalContT $ do
-    _ <- startNode (NetCfg 0 0) apiNode [] db s0
+    _ <- startNode (NodeCfg 0 0 []) apiNode db s0
     lift $ lift $ do -- Establish connection
       --
       -- FIXME: we need to do something better than fixed delay

--- a/hschain-PoW/test/TM/Store.hs
+++ b/hschain-PoW/test/TM/Store.hs
@@ -49,7 +49,7 @@ testRestart = do
           }
     db   <- lift $ blockDatabase genesisCoin
     c0   <- lift $ createConsensus db startingState =<< buildBlockIndex db
-    pow  <- startNode netcfg net [] db c0
+    pow  <- startNode netcfg net db c0
     cforkLinked $ genericMiningLoop mine pow
     -- Await for new blocks
     ch   <- atomicallyIO $ chainUpdate pow
@@ -63,9 +63,10 @@ testRestart = do
   where
     startingState :: DummyState (HSChainT IO) Coin
     startingState = DummyState (blockID genesisCoin) (error "No rewind past genesis")
-    netcfg = NetCfg { nKnownPeers     = 3
-                    , nConnectedPeers = 3
-                    }
+    netcfg = NodeCfg { nKnownPeers     = 3
+                     , nConnectedPeers = 3
+                     , initialPeers    = []
+                     }
 
 
 genesisCoin :: Block Coin

--- a/hschain-PoW/test/TM/Util/Mockchain.hs
+++ b/hschain-PoW/test/TM/Util/Mockchain.hs
@@ -129,13 +129,13 @@ header3' = toHeader block3'
 header4' = toHeader block4'
 
 
-data DummyState m b = DummyState (BlockID b) (DummyState m b)
+data DummyState m b = DummyState (BH b) (DummyState m b)
 
 instance (Monad m, BlockData b) => StateView (DummyState m b) where
   type BlockType (DummyState m b) = b
   type MonadOf   (DummyState m b) = m
-  stateBID (DummyState bid _) = bid
-  applyBlock prev _ bh _ = return $ Right $ DummyState (bhBID bh) prev
+  stateBH (DummyState bh _) = bh
+  applyBlock prev _ bh _ = return $ Right $ DummyState bh prev
   revertBlock (DummyState _ prev) = return prev
   flushState = return
   checkTx = error "Transaction checking is not supported"


### PR DESCRIPTION
This PR implements light node which only fetches headers and relies on full nodes for complete block validation. Supproting changes:

 - Block database allows to store headers
 - Fixed bug in block fetching when unsuccessful fetch means that block will never be fetched from another node. 
 - Refactoring of internal APIs. `view` doesn't leak into network layer. Necessary for light node which doesn't have blockchain state