### PR TITLE
use ByteRepr instead of BYtereprSized superclass constraint

### DIFF
--- a/hschain-PoW/exe/coin-node.hs
+++ b/hschain-PoW/exe/coin-node.hs
@@ -157,7 +157,9 @@ parser = do
     )
   return Opts{..}
 
-makePrivKeyStream :: forall alg. CryptoSign alg => Int -> [PrivKey alg]
+makePrivKeyStream
+  :: forall alg. (CryptoSign alg, ByteReprSized (PrivKey alg))
+  => Int -> [PrivKey alg]
 makePrivKeyStream seed
   = unfoldr step
   $ randoms (mkStdGen seed)

--- a/hschain-PoW/test/TM/Util/Mockchain.hs
+++ b/hschain-PoW/test/TM/Util/Mockchain.hs
@@ -150,7 +150,9 @@ catchAbort action = handle (\(Abort h) -> return h) action
 k1,k2 :: PrivKey Alg
 k1:k2:_ = makePrivKeyStream 1334
 
-makePrivKeyStream :: forall alg. CryptoSign alg => Int -> [PrivKey alg]
+makePrivKeyStream
+  :: forall alg. (CryptoSign alg, ByteReprSized (PrivKey alg))
+  => Int -> [PrivKey alg]
 makePrivKeyStream seed
   = unfoldr step
   $ randoms (mkStdGen seed)

--- a/hschain-crypto-bls/tests/TM/BLS.hs
+++ b/hschain-crypto-bls/tests/TM/BLS.hs
@@ -168,7 +168,8 @@ tests = testGroup "BLS"
 
 
 testsAsymmetricCrypto
-  :: forall alg. (CryptoAsymmetric alg, Eq (PrivKey alg))
+  :: forall alg. ( CryptoAsymmetric alg, Eq (PrivKey alg)
+                 , ByteReprSized (PublicKey alg), ByteReprSized (PrivKey alg))
   => Proxy alg -> [TestTree]
 testsAsymmetricCrypto tag =
   [ testGroup "PrivKey"   $ testsStdIntances (Proxy @(PrivKey   alg))
@@ -192,7 +193,7 @@ testsAsymmetricCrypto tag =
 
 
 testsSignatureCrypto
-  :: forall alg. CryptoSign alg
+  :: forall alg. (CryptoSign alg, ByteReprSized (Signature alg))
   => Proxy alg -> [TestTree]
 testsSignatureCrypto tag =
   [ testGroup "Signature"   $ testsStdIntances (Proxy @(Signature   alg))

--- a/hschain-crypto/HSChain/Crypto.hs
+++ b/hschain-crypto/HSChain/Crypto.hs
@@ -560,20 +560,7 @@ instance StreamCypher alg => JSON.ToJSONKey   (CypherNonce alg) where
   toJSONKey = defaultToJsonKey
 
 
-
-----------------------------------------------------------------
--- Signing and verification of values
-----------------------------------------------------------------
-
--- | Whether signature has been verified or not. Note that all data
---   coming from external sources should be treated as unverified
---   therefore only @Signed 'Unverified@ has instances for
---   serialization
-data SignedState = Verified
-                 | Unverified
-
-
-
+----------------------------------------
 
 instance CryptoAsymmetric alg => CryptoHashable (PublicKey alg) where
   hashStep k
@@ -590,3 +577,14 @@ instance CryptoAsymmetric alg => CryptoHashable (Signature alg) where
     = hashStep (CrySignature $ getCryptoName (asymmKeyAlgorithmName @alg))
    <> hashStep (encodeToBS k)
 
+
+----------------------------------------------------------------
+-- Signing and verification of values
+----------------------------------------------------------------
+
+-- | Whether signature has been verified or not. Note that all data
+--   coming from external sources should be treated as unverified
+--   therefore only @Signed 'Unverified@ has instances for
+--   serialization
+data SignedState = Verified
+                 | Unverified

--- a/hschain-crypto/HSChain/Crypto.hs
+++ b/hschain-crypto/HSChain/Crypto.hs
@@ -156,8 +156,8 @@ data family PublicKey alg
 -- | Cryptographical algorithms with asymmetrical keys. This is base
 --   class which doesn;t provide any interesting functionality except
 --   for generation of keys and coversion private to public.
-class ( ByteReprSized (PublicKey alg)
-      , ByteReprSized (PrivKey   alg)
+class ( ByteRepr (PublicKey alg)
+      , ByteRepr (PrivKey   alg)
       , Ord (PublicKey alg)
       ) => CryptoAsymmetric alg where
   -- | Compute public key from  private key
@@ -173,7 +173,7 @@ newtype Signature alg = Signature ByteString
   deriving newtype (Eq, Ord, Serialise, NFData)
 
 
-class ( ByteReprSized (Signature   alg)
+class ( ByteRepr (Signature alg)
       , CryptoAsymmetric alg
       ) => CryptoSign alg where
   -- | Sign sequence of bytes
@@ -214,7 +214,7 @@ data family DHSecret alg
 
 -- | Cryptographical algorithm that support some variant of
 --   Diffie-Hellman key exchange
-class ( ByteReprSized (DHSecret alg)
+class ( ByteRepr (DHSecret alg)
       , CryptoAsymmetric alg
       ) => CryptoDH alg where
   -- | Calculate shared secret from private and public key. Following
@@ -225,19 +225,19 @@ class ( ByteReprSized (DHSecret alg)
 
 
 -- | Size of public key in bytes
-publicKeySize :: forall alg proxy i. (CryptoAsymmetric alg, Num i) => proxy alg -> i
+publicKeySize :: forall alg proxy i. (ByteReprSized (PublicKey alg), Num i) => proxy alg -> i
 publicKeySize _ = fromIntegral $ natVal (Proxy @(ByteSize (PublicKey alg)))
 
 -- | Size of private key in bytes
-privKeySize :: forall alg proxy i. (CryptoAsymmetric alg, Num i) => proxy alg -> i
+privKeySize :: forall alg proxy i. (ByteReprSized (PrivKey alg), Num i) => proxy alg -> i
 privKeySize _ = fromIntegral $ natVal (Proxy @(ByteSize (PrivKey alg)))
 
 -- | Size of signature in bytes
-signatureSize :: forall alg proxy i. (CryptoSign alg, Num i) => proxy alg -> i
+signatureSize :: forall alg proxy i. (ByteReprSized (Signature alg), Num i) => proxy alg -> i
 signatureSize _ = fromIntegral $ natVal (Proxy @(ByteSize (Signature alg)))
 
 -- | Size of signature in bytes
-dhSecretSize :: forall alg proxy i. (CryptoDH alg, Num i) => proxy alg -> i
+dhSecretSize :: forall alg proxy i. (ByteReprSized (DHSecret alg), Num i) => proxy alg -> i
 dhSecretSize _ = fromIntegral $ natVal (Proxy @(ByteSize (DHSecret alg)))
 
 

--- a/hschain-crypto/test/TM/Crypto.hs
+++ b/hschain-crypto/test/TM/Crypto.hs
@@ -95,7 +95,8 @@ testsNaClBox = testGroup "Tests for NaCl box"
   ]
 
 testsAsymmetricCrypto
-  :: forall alg. (CryptoAsymmetric alg, Eq (PrivKey alg))
+  :: forall alg. ( CryptoAsymmetric alg, Eq (PrivKey alg)
+                 , ByteReprSized (PublicKey alg), ByteReprSized (PrivKey alg))
   => Proxy alg -> [TestTree]
 testsAsymmetricCrypto tag =
   [ testGroup "PrivKey"   $ testsStdIntances (Proxy @(PrivKey   alg))
@@ -119,7 +120,7 @@ testsAsymmetricCrypto tag =
 
 
 testsSignatureCrypto
-  :: forall alg. CryptoSign alg
+  :: forall alg. (CryptoSign alg, ByteReprSized (Signature alg))
   => Proxy alg -> [TestTree]
 testsSignatureCrypto tag =
   [ testGroup "Signature"   $ testsStdIntances (Proxy @(Signature   alg))

--- a/hschain-examples/HSChain/Mock/KeyList.hs
+++ b/hschain-examples/HSChain/Mock/KeyList.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
@@ -76,7 +77,9 @@ connectRing vals addr =
 --   function is very useful for testing since it allows to generate a
 --   lot of keys quickly and in deterministic manner. Naturally it
 --   shoulldn't be used in production
-makePrivKeyStream :: forall alg. CryptoSign alg => Int -> [PrivKey alg]
+makePrivKeyStream
+  :: forall alg. (CryptoSign alg, ByteReprSized (PrivKey alg))
+  => Int -> [PrivKey alg]
 makePrivKeyStream seed
   = unfoldr step
   $ randoms (mkStdGen seed)

--- a/hschain-quickcheck/HSChain/Arbitrary/Instances.hs
+++ b/hschain-quickcheck/HSChain/Arbitrary/Instances.hs
@@ -49,7 +49,7 @@ instance (CryptoSign alg, Arbitrary a) => Arbitrary (Signed sign alg a) where
 
 instance CryptoSign alg => Arbitrary (PublicKey alg) where
   arbitrary = do
-    bs <- vectorOf (privKeySize (Proxy @alg)) arbitrary
+    bs <- vectorOf (publicKeySize (Proxy @alg)) arbitrary
     return $ fromJust $ decodeFromBS $ BS.pack bs
   shrink _ = []
 

--- a/hschain-quickcheck/HSChain/Arbitrary/Instances.hs
+++ b/hschain-quickcheck/HSChain/Arbitrary/Instances.hs
@@ -39,21 +39,21 @@ instance Arbitrary (Hash alg) => Arbitrary (Hashed alg a) where
   arbitrary = Hashed <$> arbitrary
   shrink  _ = []
 
-instance CryptoSign alg => Arbitrary (Signature alg) where
+instance (ByteReprSized (Signature alg)) => Arbitrary (Signature alg) where
   arbitrary = Signature <$> Arb.fastRandBs (signatureSize (Proxy @alg))
   shrink _ = []
 
-instance (CryptoSign alg, Arbitrary a) => Arbitrary (Signed sign alg a) where
+instance (ByteReprSized (Signature alg), Arbitrary a) => Arbitrary (Signed sign alg a) where
   arbitrary = genericArbitrary
   shrink = genericShrink
 
-instance CryptoSign alg => Arbitrary (PublicKey alg) where
+instance (ByteReprSized (PublicKey alg)) => Arbitrary (PublicKey alg) where
   arbitrary = do
     bs <- vectorOf (publicKeySize (Proxy @alg)) arbitrary
     return $ fromJust $ decodeFromBS $ BS.pack bs
   shrink _ = []
 
-instance CryptoSign alg => Arbitrary (PrivKey alg) where
+instance (ByteReprSized (PrivKey alg)) => Arbitrary (PrivKey alg) where
   arbitrary = do
     bs <- vectorOf (privKeySize (Proxy @alg)) arbitrary
     return $ fromJust $ decodeFromBS $ BS.pack bs
@@ -63,7 +63,7 @@ instance Arbitrary (KDFOutput alg) where
   arbitrary = KDFOutput <$> Arb.fastRandBs 256
   shrink  _ = []
 
-instance CryptoDH alg => Arbitrary (DHSecret alg) where
+instance (ByteReprSized (DHSecret alg)) => Arbitrary (DHSecret alg) where
   arbitrary = do
     bs <- vectorOf (dhSecretSize (Proxy @alg)) arbitrary
     return $ fromJust $ decodeFromBS $ BS.pack bs
@@ -113,7 +113,7 @@ instance Arbitrary Round where
     arbitrary = Round <$> arbitrary
     shrink = genericShrink
 
-instance (Crypto (Alg a)) => Arbitrary (Commit a) where
+instance (Crypto (Alg a), ByteReprSized (Signature (Alg a))) => Arbitrary (Commit a) where
   arbitrary = Commit <$> arbitrary
                      <*> ((NE.:|) <$> arbitrary <*> resize 3 arbitrary)
 
@@ -131,6 +131,7 @@ instance ( Crypto (Alg a)
          , IsMerkle f
          , CryptoHashable a
          , Arbitrary a
+         , ByteReprSized (Signature (Alg a))
          ) => Arbitrary (GBlock f a) where
   arbitrary = Block <$> arbitrary
                     <*> arbitrary
@@ -141,7 +142,7 @@ instance ( Crypto (Alg a)
                     <*> arbitrary
   shrink = genericShrink
 
-instance (Crypto (Alg a)) => Arbitrary (ByzantineEvidence a) where
+instance (Crypto (Alg a), ByteReprSized (Signature (Alg a))) => Arbitrary (ByzantineEvidence a) where
   arbitrary = genericArbitrary
   shrink = genericShrink
 
@@ -162,7 +163,8 @@ instance (Ord (PublicKey alg), Arbitrary (PublicKey alg)) => Arbitrary (Validato
       return (k,p)
     return $ ValidatorChange $ Map.fromList pairs
 
-instance (Eq (PublicKey alg), CryptoSign alg) => Arbitrary (ValidatorSet alg) where
+instance (Eq (PublicKey alg), CryptoSign alg, ByteReprSized (PublicKey alg)
+         ) => Arbitrary (ValidatorSet alg) where
   arbitrary = do
     n     <- choose (0,10)
     pairs <- replicateM n arbitrary
@@ -174,7 +176,7 @@ instance (Eq (PublicKey alg), CryptoSign alg) => Arbitrary (ValidatorSet alg) wh
     | vset' <-  shrink $ asValidatorList vset
     ]
 
-instance CryptoSign alg => Arbitrary (Validator alg) where
+instance (ByteReprSized (PublicKey alg), CryptoSign alg) => Arbitrary (Validator alg) where
   arbitrary = Validator <$> arbitrary <*> choose (1,10)
 
 instance Arbitrary (ValidatorIdx alg) where

--- a/hschain-types/test/TM/Time.hs
+++ b/hschain-types/test/TM/Time.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass      #-}
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
@@ -118,7 +119,9 @@ privateKeyList :: [PrivKey (Alg BData)]
 privateKeyList = makePrivKeyStream 13337
 
 -- Sadly (code duplication. Same function is defined in hschain-examples)
-makePrivKeyStream :: forall alg. CryptoSign alg => Int -> [PrivKey alg]
+makePrivKeyStream
+  :: forall alg. (ByteReprSized (PrivKey alg), CryptoSign alg)
+  => Int -> [PrivKey alg]
 makePrivKeyStream seed
   = unfoldr step
   $ randoms (mkStdGen seed)


### PR DESCRIPTION
Practice showed that it's not used in normal code and only appear in
testing. And testing harness can very well have one more constraint